### PR TITLE
add tooltip comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+Contains information from the language-subtag-registry JSON Database (https://github.com/mattcg/language-subtag-registry/tree/master/data/json)
+which is made available under the ODC Attribution License (https://github.com/mattcg/language-subtag-registry/blob/master/LICENSE.md).

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,6 +1,14 @@
 export interface BannerProps {
-  title?: string, // this is the title for doing things blahblah
+  /** Banner title! */
+  title?: string,
+  /** 
+   * Some random
+   * number to display!
+   */
   randomNum?: number,
+  /**
+   * A boolean to toggle nothing..
+   */
   someBool?: boolean,
 }
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "lib",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noImplicitAny": false,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "jsx": "react-jsx",
+    "target": "esnext",
+  }
+}

--- a/studio/client/components/PropEditor.tsx
+++ b/studio/client/components/PropEditor.tsx
@@ -24,12 +24,14 @@ export default function PropEditor({
     <>
       {
         Object.keys(propShape).map(propName => {
-          const propType = propShape[propName]
+          const propType = propShape[propName].type
+          const propDoc = propShape[propName].doc
           const propValue = propState[propName] as any
           const sharedProps ={
             key: propName,
             propName,
             propValue,
+            propDoc,
             onChange: val => updatePropState(propName, val)
           }
           if (propType === 'boolean') {
@@ -49,11 +51,13 @@ export default function PropEditor({
 function BoolProp(props: {
   propName: string,
   propValue: boolean,
+  propDoc?: string,
   onChange: (val: boolean) => void
 }) {
   return (
     <div className='flex'>
-      <label className='label'>{props.propName}:</label>
+      <label className='peer label'>{props.propName}:</label>
+      {props.propDoc && <ToolTip message={props.propDoc}/>}
       <input className='checkbox' type='checkbox' onChange={e => props.onChange(e.target.checked)} checked={props.propValue ?? false}/>
     </div>
   )
@@ -62,11 +66,13 @@ function BoolProp(props: {
 function StrProp(props: {
   propName: string,
   propValue: string,
+  propDoc?: string,
   onChange: (val: string) => void
 }) {
   return (
     <div className='flex'>
-      <label className='label'>{props.propName}:</label>
+      <label className='peer label'>{props.propName}:</label>
+      {props.propDoc && <ToolTip message={props.propDoc}/>}
       <input className='input-sm' onChange={e => props.onChange(e.target.value)} value={props.propValue ?? ''}/>
     </div>
   )
@@ -75,12 +81,24 @@ function StrProp(props: {
 function NumProp(props: {
   propName: string,
   propValue: number,
+  propDoc?: string,
   onChange: (val: number) => void
 }) {
   return (
     <div className='flex'>
-      <label className='label'>{props.propName}:</label>
+      <label className='peer label'>{props.propName}:</label>
+      {props.propDoc && <ToolTip message={props.propDoc}/>}
       <input className='input-sm' onChange={e => props.onChange(parseFloat(e.target.value))} value={props.propValue ?? ''}/>
+    </div>
+  )
+}
+
+function ToolTip(props: {
+  message: string
+}) {
+  return (
+    <div className='invisible peer-hover:visible'>
+      <div className='absolute z-10 whitespace-nowrap rounded shadow-lg p-3 text-sm bg-gray-600 text-white'>{props.message}</div>
     </div>
   )
 }

--- a/studio/client/components/Studio.tsx
+++ b/studio/client/components/Studio.tsx
@@ -19,7 +19,7 @@ export interface StudioProps {
 }
 
 export default function Studio(props: StudioProps) {
-  const { componentsOnPage, componentsToPropShapes } = props;
+  const { componentsOnPage, componentsToPropShapes } = props
   const [pageComponentsState, setPageComponentsState] = useState(componentsOnPage.index)
 
   return (

--- a/studio/shared/models.ts
+++ b/studio/shared/models.ts
@@ -3,4 +3,9 @@ export type PageComponentsState = {
   props: Record<string, number | string | boolean>
 }[]
 
-export type TSPropShape = Record<string, 'string' | 'number' | 'boolean'>
+export type TSPropMetadata = {
+  type: 'string' | 'number' | 'boolean',
+  doc?: string
+}
+
+export type TSPropShape = Record<string, TSPropMetadata>

--- a/studio/studio-plugin/__fixtures__/components/Banner.tsx
+++ b/studio/studio-plugin/__fixtures__/components/Banner.tsx
@@ -1,9 +1,15 @@
-import { ColorProp } from './SpecialProps';
+import { ColorProp } from './SpecialProps'
 
 export interface BannerProps {
-  title?: string, // this is the title for doing things blahblah
+  title?: string, // this is trailing comment
+  /** jsdoc single line */
   randomNum?: number,
+  /**
+   * this is a jsdoc
+   * multi-line comments!
+   */
   someBool?: boolean,
+  // this is a leading comment
   backgroundColor?: ColorProp
 }
 

--- a/studio/studio-plugin/createStudioPlugin.ts
+++ b/studio/studio-plugin/createStudioPlugin.ts
@@ -2,6 +2,7 @@ import { Plugin } from 'vite'
 import parsePropInterface from './ts-morph/parsePropInterface'
 import parsePageFile from './ts-morph/parsePageFile'
 import configureServer from './configureServer'
+import { StudioProps } from '../client/components/Studio'
 
 /**
  * Handles server-client communication.
@@ -13,7 +14,7 @@ export default function createStudioPlugin(): Plugin {
   const virtualModuleId = 'virtual:yext-studio'
   const resolvedVirtualModuleId = '\0' + virtualModuleId
 
-  const ctx = {
+  const ctx: StudioProps = {
     componentsToPropShapes: {
       Banner: parsePropInterface('src/components/Banner.tsx', 'BannerProps')
     },

--- a/studio/studio-plugin/ts-morph/parsePropInterface.test.ts
+++ b/studio/studio-plugin/ts-morph/parsePropInterface.test.ts
@@ -5,9 +5,19 @@ jest.mock('../getRootPath')
 it('updates correctly', () => {
   const propShape = parsePropInterface('components/Banner.tsx', 'BannerProps')
   expect(propShape).toEqual({
-    title: 'string',
-    randomNum: 'number',
-    someBool: 'boolean',
-    backgroundColor: 'ColorProp'
+    title: {
+      type: 'string'
+    },
+    randomNum: {
+      type: 'number',
+      doc: 'jsdoc single line'
+    },
+    someBool: {
+      type: 'boolean',
+      doc: '\nthis is a jsdoc\nmulti-line comments!'
+    },
+    backgroundColor: {
+      type: 'ColorProp'
+    }
   })
 })

--- a/studio/studio-plugin/ts-morph/parsePropInterface.ts
+++ b/studio/studio-plugin/ts-morph/parsePropInterface.ts
@@ -10,15 +10,19 @@ export default function parsePropInterface(filePath: string, componentPropsName:
   const sourceFile = p.getSourceFileOrThrow(file)
   const propsInterface = sourceFile.getDescendantsOfKind(ts.SyntaxKind.InterfaceDeclaration).find(n => {
     return n.getName() === componentPropsName
-  });
+  })
   if (!propsInterface) {
     throw new Error(`No interface found with name "${componentPropsName}" in file "${filePath}"`)
   }
-  const structure = propsInterface.getStructure();
-  const properties = structure.properties ?? [];
+  const structure = propsInterface.getStructure()
+  const properties = structure.properties ?? []
   const props: TSPropShape = {}
   properties.forEach(p => {
-    props[p.name] = p.type as 'string' | 'number' | 'boolean'
+    const jsdoc = p.docs?.map(doc => typeof doc === 'string' ? doc : doc.description).join('\n')
+    props[p.name] = {
+      type: p.type as 'string' | 'number' | 'boolean',
+      ...(jsdoc && { doc: jsdoc })
+    }
   })
   return props
 }


### PR DESCRIPTION
Turn comments in props into tooltips. Currently this will only parse JSDoc from the interface, meaning any leading or trailing comments will be omitted.

- update TSPropShape model to store the type AND doc for each field in a prop interface
- added tooltip UI to each of the supported propEditor type: boolean, number, component
- added a tsconfig to src/ folder to remove errors about needing to import react

J=SLAP-2215
TEST=manual&auto

see that jest test pass for parsePropInterface.test.ts

added comments to Banner component's prop interface, hover over the label on the propEditor and see that tool tip pop up with the corresponding comments.
![Screen Shot 2022-07-13 at 11 50 32 AM](https://user-images.githubusercontent.com/36055303/178776764-2e456d9b-adc5-4bea-b932-6f814e8f5f49.png)
![Screen Shot 2022-07-13 at 11 50 52 AM](https://user-images.githubusercontent.com/36055303/178776836-e83a6e21-2f3d-468b-a6b4-507d05284133.png)

