### PR TITLE
move states to StudioContext

### DIFF
--- a/studio/client/components/AddComponentButton.tsx
+++ b/studio/client/components/AddComponentButton.tsx
@@ -1,14 +1,7 @@
-import { Dispatch, SetStateAction } from 'react';
-import { PageComponentsState, TSPropShape } from '../../shared/models';
+import { useStudioContext } from './useStudioContext'
 
-export default function AddComponentButton(props: {
-  componentsToPropShapes: {
-    Banner: TSPropShape
-  },
-  pageComponentsState: PageComponentsState,
-  setPageComponentsState: Dispatch<SetStateAction<PageComponentsState>>
-}) {
-  const { componentsToPropShapes, pageComponentsState, setPageComponentsState } = props;
+export default function AddComponentButton() {
+  const { componentsToPropShapes, pageComponentsState, setPageComponentsState } = useStudioContext()
 
   return (
     <div className="dropdown mb-2">

--- a/studio/client/components/PagePreview.tsx
+++ b/studio/client/components/PagePreview.tsx
@@ -1,12 +1,10 @@
 import React, { FunctionComponent, useEffect } from 'react'
 import { useState } from 'react'
 import { PageComponentsState } from '../../shared/models'
+import { useStudioContext } from './useStudioContext'
 
-export default function PagePreview({
-  pageComponentsState
-}: {
-  pageComponentsState: PageComponentsState
-}) {
+export default function PagePreview() {
+  const { pageComponentsState } = useStudioContext()
   const [componentNameToComponent, loadedComponents] = useComponents(pageComponentsState)
 
   return (

--- a/studio/client/components/Studio.tsx
+++ b/studio/client/components/Studio.tsx
@@ -7,11 +7,10 @@ import PagePreview from './PagePreview'
 import { PageComponentsState } from '../../shared/models'
 import { MessageID } from '../../shared/messages'
 import AddComponentButton from './AddComponentButton'
+import { StudioContext } from './useStudioContext'
 
 export interface StudioProps {
-  componentsToPropShapes: {
-    Banner: TSPropShape
-  },
+  componentsToPropShapes: Record<string, TSPropShape>,
   // only supports a page named "index" for now
   componentsOnPage: {
     index: PageComponentsState
@@ -23,25 +22,23 @@ export default function Studio(props: StudioProps) {
   const [pageComponentsState, setPageComponentsState] = useState(componentsOnPage.index)
 
   return (
-    <div className='h-screen w-screen flex flex-row'>
-      <div className='h-screen w-2/5 bg-slate-500 flex flex-col'>
-        <h1 className='text-3xl text-white'>Yext Studio</h1>
-        <AddComponentButton
-          componentsToPropShapes={componentsToPropShapes}
-          pageComponentsState={pageComponentsState}
-          setPageComponentsState={setPageComponentsState}
-        />
-        {renderPropEditors(props, pageComponentsState, setPageComponentsState)}
-        <button className='btn' onClick={() => sendMessage(MessageID.UpdatePageComponentProps, {
-          path: 'src/pages/index.tsx',
-          state: pageComponentsState
-        })}>
-          Update Component Props
-        </button>
-        <SiteSettings />
+    <StudioContext.Provider value={{ componentsToPropShapes, pageComponentsState, setPageComponentsState }}>
+      <div className='h-screen w-screen flex flex-row'>
+        <div className='h-screen w-2/5 bg-slate-500 flex flex-col'>
+          <h1 className='text-3xl text-white'>Yext Studio</h1>
+          <AddComponentButton />
+          {renderPropEditors(props, pageComponentsState, setPageComponentsState)}
+          <button className='btn' onClick={() => sendMessage(MessageID.UpdatePageComponentProps, {
+            path: 'src/pages/index.tsx',
+            state: pageComponentsState
+          })}>
+            Update Component Props
+          </button>
+          <SiteSettings />
+        </div>
+        <PagePreview />
       </div>
-      <PagePreview pageComponentsState={pageComponentsState}/>
-    </div>
+    </StudioContext.Provider>
   )
 }
 

--- a/studio/client/components/useStudioContext.tsx
+++ b/studio/client/components/useStudioContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react'
+import { PageComponentsState, TSPropShape } from '../../shared/models'
+
+export interface StudioContextType {
+  componentsToPropShapes: Record<string, TSPropShape>,
+  pageComponentsState: PageComponentsState,
+  setPageComponentsState: React.Dispatch<React.SetStateAction<PageComponentsState>>
+}
+
+export const StudioContext = createContext<StudioContextType | null>(null)
+
+export function useStudioContext(): StudioContextType {
+  const studioContext = useContext(StudioContext)
+  if (studioContext === null) {
+    throw new Error('Tried to use StudioContext when none exists.')
+  }
+  return studioContext
+}


### PR DESCRIPTION
Added StudioContext, which stores componentsToPropShapes, pageComponentsState, setPageComponentsState to avoid having to pass them around as props in different components

J=SLAP-2239
TEST=auto&manual

ran `npm run dev` successfully and smoke tested the page