### PR TITLE
Fix UI bug with right click context menu

### DIFF
--- a/studio/client/components/DraggablePropEditor.tsx
+++ b/studio/client/components/DraggablePropEditor.tsx
@@ -35,7 +35,7 @@ export default function DraggablePropEditor(props: DraggablePropEditorProps) {
 
   const handleContextMenu = useCallback((e) => {
     e.preventDefault()
-    setContextMenuAnchor({ x: e.pageX, y: e.pageY })
+    setContextMenuAnchor({ x: e.x, y: e.y })
     toggleContextMenu(true)
   }, [setContextMenuAnchor, toggleContextMenu])
 


### PR DESCRIPTION
Fix bug where right clicking the components when the page was scrolled would cause the context menu to appear lower on the page compared to where the mouse click was.

J=SLAP-2262
TEST=manual

See that the context menu appears next to the mouse click when right clicking on a component even when the page is scrolled.