### PR TITLE
Use import.meta.glob for localComponents

### DIFF
--- a/studio/client/components/PagePreview.tsx
+++ b/studio/client/components/PagePreview.tsx
@@ -41,7 +41,7 @@ function useComponents(
   moduleNameToComponentMetadata: ModuleNameToComponentMetadata
 ): [PageComponentsState] {
   const [loadedComponents, setLoadedComponents] = useState<PageComponentsState>([])
-  const modules = import.meta.glob<object>('../../../src/components/*.tsx')
+  const modules = import.meta.glob<Record<string, unknown>>('../../../src/components/*.tsx')
 
   useEffect(() => {
     Promise.all(pageComponentsState.map(c => {
@@ -72,7 +72,7 @@ function useComponents(
   return [loadedComponents]
 }
 
-function getFunctionComponent(module: object, name: string):
+function getFunctionComponent(module: Record<string, unknown>, name: string):
 (FunctionComponent<Record<string, unknown>> | string) {
   if (typeof module[name] === 'function') {
     return module[name] as FunctionComponent


### PR DESCRIPTION
Used `import.meta.glob` instead of dynamic imports for `localComponents`. Also added type checking for modules.

Had to add an eslint-disable to assert that `module` is `any` on line 60 (`module` is also type `any` on the npm dynamic imports line)

J=SLAP-2260
TEST=auto