### PR TITLE
use generic InputProp for all the different prop types in PropEditor

### DIFF
--- a/studio/client/components/PropEditor.tsx
+++ b/studio/client/components/PropEditor.tsx
@@ -85,7 +85,7 @@ function InputProp<T extends string | number | boolean>(props: {
           className='checkbox'
           type='checkbox'
           onChange={e => onChange(e.target.checked as T)}
-          checked={!!propValue ?? defaultValue}
+          checked={propValue as boolean ?? defaultValue}
         />
         : <input
           className='input-sm'


### PR DESCRIPTION
Consolidate NumProp, StrProp, HexColorProp, etc to use a generic `InputProp` 

J=SLAP-2334
TEST=manual

run `npm run dev`, make changes to props and saved. See that there's no error encountered.