### PR TITLE
default value for InputProp

### DIFF
--- a/studio/client/components/PropEditor.tsx
+++ b/studio/client/components/PropEditor.tsx
@@ -85,13 +85,13 @@ function InputProp<T extends string | number | boolean>(props: {
           className='checkbox'
           type='checkbox'
           onChange={e => onChange(e.target.checked as T)}
-          checked={propValue as boolean ?? defaultValue}
+          checked={propValue as boolean ?? defaultValue ?? false}
         />
         : <input
           className='input-sm'
           type={type}
           onChange={e => onChange(e.target.value as T)}
-          value={propValue as string | number ?? defaultValue}
+          value={propValue as string | number ?? defaultValue ?? ''}
         />
       }
       {img}


### PR DESCRIPTION
Added hardcoded default value in InputProp to address this issue when user add a new component with no default value.

<img width="679" alt="Screen Shot 2022-08-23 at 10 47 40 AM" src="https://user-images.githubusercontent.com/36055303/186189970-10a3f4b3-fec7-4303-a1f8-eda0372e8c34.png">

See that error is gone after the change.