### PR TITLE
fix NON_CONFIGURABLE_PROPERTIES not being filtered out of streams

### DIFF
--- a/studio/studio-plugin/streams/getUpdatedStreamConfig.ts
+++ b/studio/studio-plugin/streams/getUpdatedStreamConfig.ts
@@ -29,8 +29,8 @@ export default function getUpdatedStreamConfig(
   const streamValues = getStreamValues(componentsState)
   const usedDocumentPaths = getUsedDocumentPaths(streamValues)
   const fields = [...usedDocumentPaths]
-    .filter(documentPath => !NON_CONFIGURABLE_PROPERTIES.includes(documentPath))
     .map(documentPath => documentPath.split('document.')[1])
+    .filter(documentPath => !NON_CONFIGURABLE_PROPERTIES.includes(documentPath))
 
   return {
     ...currentConfig,


### PR DESCRIPTION
the filter needs to come after the map

TEST=manual

see that "id" no longer gets specified on save