### PR TITLE
prevent drop if target does not accept children

### DIFF
--- a/studio/client/components/ComponentTree.tsx
+++ b/studio/client/components/ComponentTree.tsx
@@ -18,16 +18,16 @@ type ValidatedNodeList = (Node & {
 })[]
 
 export default function ComponentTree() {
-  const { pageState, setPageState } = useStudioContext()
+  const { pageState, setPageState, moduleNameToComponentMetadata } = useStudioContext()
   const tree = useMemo(() => {
     return pageState.componentsState.map(c => ({
       id: c.uuid,
       parent: c.parentUUID ?? ROOT_ID,
       text: c.name,
-      droppable: true,
+      droppable: moduleNameToComponentMetadata[c.moduleName][c.name].acceptsChildren,
       data: c
     }))
-  }, [pageState.componentsState])
+  }, [moduleNameToComponentMetadata, pageState.componentsState])
 
   const handleDrop = useCallback((tree: Node[]) => {
     validateTreeOrThrow(tree)
@@ -67,7 +67,10 @@ export default function ComponentTree() {
 }
 
 function canDrop(_: Node[], opts: DropOptions<ComponentState>) {
-  const { dragSource, dropTargetId } = opts
+  const { dragSource, dropTargetId, dropTarget } = opts
+  if (dropTarget !== undefined && !dropTarget.droppable) {
+    return false
+  }
   if (dragSource?.parent === dropTargetId || dropTargetId === ROOT_ID) {
     return true
   }

--- a/studio/client/components/PropEditor.tsx
+++ b/studio/client/components/PropEditor.tsx
@@ -132,8 +132,8 @@ export function InputProp<T extends string | number | boolean>(props: {
             onChange={onSimpleInputPropChange}
           />
         }
-        {isExpression && getExpressionSources(propValue)
-          .every(s => s === ExpressionSourceType.Stream) ? <KGLogo /> : <ExpressionLogo />}
+        {isExpression && (getExpressionSources(propValue)
+          .every(s => s === ExpressionSourceType.Stream) ? <KGLogo /> : <ExpressionLogo />)}
       </div>
     </div>
   )


### PR DESCRIPTION
Do not allow drag and drop when the target component's metadata have `acceptsChildren` as false

J=SLAP-2381
TEST=manual

On the left bar, verify that a component can move into a Card (acceptsChildren: true) but not a Banner (acceptsChildren: false)