### PR TITLE
move required dependencies out of devDep for Studio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1450,7 +1450,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz",
       "integrity": "sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6"
       },
@@ -1465,7 +1464,6 @@
       "version": "7.19.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.19.6.tgz",
       "integrity": "sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.19.0"
       },
@@ -2202,7 +2200,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2218,7 +2215,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -4105,7 +4101,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-2.2.0.tgz",
       "integrity": "sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==",
-      "dev": true,
       "dependencies": {
         "@babel/core": "^7.19.6",
         "@babel/plugin-transform-react-jsx": "^7.19.0",
@@ -6604,7 +6599,6 @@
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.16.tgz",
       "integrity": "sha512-o6iS9zxdHrrojjlj6pNGC2NAg86ECZqIETswTM5KmJitq+R1YmahhWtMumeQp9lHqJaROGnsBi2RLawGnfo5ZQ==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -6644,7 +6638,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -6660,7 +6653,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -6676,7 +6668,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -6692,7 +6683,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -6708,7 +6698,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -6724,7 +6713,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -6740,7 +6728,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6756,7 +6743,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6772,7 +6758,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6788,7 +6773,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6804,7 +6788,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6820,7 +6803,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6836,7 +6818,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6852,7 +6833,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6868,7 +6848,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -6884,7 +6863,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -6900,7 +6878,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -6916,7 +6893,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -6932,7 +6908,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -6948,7 +6923,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -11753,7 +11727,6 @@
       "version": "0.26.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
       "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
-      "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
       },
@@ -16319,7 +16292,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.4.tgz",
       "integrity": "sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==",
-      "dev": true,
       "dependencies": {
         "esbuild": "^0.15.9",
         "postcss": "^8.4.18",
@@ -17287,8 +17259,10 @@
     "packages/studio": {
       "version": "0.0.0",
       "dependencies": {
+        "@vitejs/plugin-react": "^2.2.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "vite": "^3.2.3"
       },
       "bin": {
         "studio": "lib/bin/studio.js"
@@ -17302,7 +17276,6 @@
         "@types/react-dom": "^18.0.8",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
-        "@vitejs/plugin-react": "^2.2.0",
         "@yext/eslint-config": "^1.0.0",
         "@yext/eslint-plugin-export-star": "^1.0.2",
         "eslint": "^8.11.0",
@@ -17310,8 +17283,7 @@
         "eslint-plugin-react-perf": "^3.3.1",
         "eslint-plugin-tsdoc": "^0.2.17",
         "prettier": "2.7.1",
-        "typescript": "^4.6.4",
-        "vite": "^3.2.3"
+        "typescript": "^4.6.4"
       }
     },
     "packages/studio/node_modules/@types/node": {
@@ -18239,7 +18211,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz",
       "integrity": "sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
       }
@@ -18248,7 +18219,6 @@
       "version": "7.19.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.19.6.tgz",
       "integrity": "sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.19.0"
       }
@@ -18709,14 +18679,12 @@
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.16.tgz",
       "integrity": "sha512-nyB6CH++2mSgx3GbnrJsZSxzne5K0HMyNIWafDHqYy7IwxFc4fd/CgHVZXr8Eh+Q3KbIAcAe3vGyqIPhGblvMQ==",
-      "dev": true,
       "optional": true
     },
     "@esbuild/linux-loong64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.16.tgz",
       "integrity": "sha512-SDLfP1uoB0HZ14CdVYgagllgrG7Mdxhkt4jDJOKl/MldKrkQ6vDJMZKl2+5XsEY/Lzz37fjgLQoJBGuAw/x8kQ==",
-      "dev": true,
       "optional": true
     },
     "@eslint/eslintrc": {
@@ -20099,7 +20067,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-2.2.0.tgz",
       "integrity": "sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==",
-      "dev": true,
       "requires": {
         "@babel/core": "^7.19.6",
         "@babel/plugin-transform-react-jsx": "^7.19.0",
@@ -21958,7 +21925,6 @@
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.16.tgz",
       "integrity": "sha512-o6iS9zxdHrrojjlj6pNGC2NAg86ECZqIETswTM5KmJitq+R1YmahhWtMumeQp9lHqJaROGnsBi2RLawGnfo5ZQ==",
-      "dev": true,
       "requires": {
         "@esbuild/android-arm": "0.15.16",
         "@esbuild/linux-loong64": "0.15.16",
@@ -21988,140 +21954,120 @@
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.16.tgz",
       "integrity": "sha512-Vwkv/sT0zMSgPSVO3Jlt1pUbnZuOgtOQJkJkyyJFAlLe7BiT8e9ESzo0zQSx4c3wW4T6kGChmKDPMbWTgtliQA==",
-      "dev": true,
       "optional": true
     },
     "esbuild-android-arm64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.16.tgz",
       "integrity": "sha512-lqfKuofMExL5niNV3gnhMUYacSXfsvzTa/58sDlBET/hCOG99Zmeh+lz6kvdgvGOsImeo6J9SW21rFCogNPLxg==",
-      "dev": true,
       "optional": true
     },
     "esbuild-darwin-64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.16.tgz",
       "integrity": "sha512-wo2VWk/n/9V2TmqUZ/KpzRjCEcr00n7yahEdmtzlrfQ3lfMCf3Wa+0sqHAbjk3C6CKkR3WKK/whkMq5Gj4Da9g==",
-      "dev": true,
       "optional": true
     },
     "esbuild-darwin-arm64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.16.tgz",
       "integrity": "sha512-fMXaUr5ou0M4WnewBKsspMtX++C1yIa3nJ5R2LSbLCfJT3uFdcRoU/NZjoM4kOMKyOD9Sa/2vlgN8G07K3SJnw==",
-      "dev": true,
       "optional": true
     },
     "esbuild-freebsd-64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.16.tgz",
       "integrity": "sha512-UzIc0xlRx5x9kRuMr+E3+hlSOxa/aRqfuMfiYBXu2jJ8Mzej4lGL7+o6F5hzhLqWfWm1GWHNakIdlqg1ayaTNQ==",
-      "dev": true,
       "optional": true
     },
     "esbuild-freebsd-arm64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.16.tgz",
       "integrity": "sha512-8xyiYuGc0DLZphFQIiYaLHlfoP+hAN9RHbE+Ibh8EUcDNHAqbQgUrQg7pE7Bo00rXmQ5Ap6KFgcR0b4ALZls1g==",
-      "dev": true,
       "optional": true
     },
     "esbuild-linux-32": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.16.tgz",
       "integrity": "sha512-iGijUTV+0kIMyUVoynK0v+32Oi8yyp0xwMzX69GX+5+AniNy/C/AL1MjFTsozRp/3xQPl7jVux/PLe2ds10/2w==",
-      "dev": true,
       "optional": true
     },
     "esbuild-linux-64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.16.tgz",
       "integrity": "sha512-tuSOjXdLw7VzaUj89fIdAaQT7zFGbKBcz4YxbWrOiXkwscYgE7HtTxUavreBbnRkGxKwr9iT/gmeJWNm4djy/g==",
-      "dev": true,
       "optional": true
     },
     "esbuild-linux-arm": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.16.tgz",
       "integrity": "sha512-XKcrxCEXDTOuoRj5l12tJnkvuxXBMKwEC5j0JISw3ziLf0j4zIwXbKbTmUrKFWbo6ZgvNpa7Y5dnbsjVvH39bQ==",
-      "dev": true,
       "optional": true
     },
     "esbuild-linux-arm64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.16.tgz",
       "integrity": "sha512-mPYksnfHnemNrvjrDhZyixL/AfbJN0Xn9S34ZOHYdh6/jJcNd8iTsv3JwJoEvTJqjMggjMhGUPJAdjnFBHoH8A==",
-      "dev": true,
       "optional": true
     },
     "esbuild-linux-mips64le": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.16.tgz",
       "integrity": "sha512-kSJO2PXaxfm0pWY39+YX+QtpFqyyrcp0ZeI8QPTrcFVQoWEPiPVtOfTZeS3ZKedfH+Ga38c4DSzmKMQJocQv6A==",
-      "dev": true,
       "optional": true
     },
     "esbuild-linux-ppc64le": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.16.tgz",
       "integrity": "sha512-NimPikwkBY0yGABw6SlhKrtT35sU4O23xkhlrTT/O6lSxv3Pm5iSc6OYaqVAHWkLdVf31bF4UDVFO+D990WpAA==",
-      "dev": true,
       "optional": true
     },
     "esbuild-linux-riscv64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.16.tgz",
       "integrity": "sha512-ty2YUHZlwFOwp7pR+J87M4CVrXJIf5ZZtU/umpxgVJBXvWjhziSLEQxvl30SYfUPq0nzeWKBGw5i/DieiHeKfw==",
-      "dev": true,
       "optional": true
     },
     "esbuild-linux-s390x": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.16.tgz",
       "integrity": "sha512-VkZaGssvPDQtx4fvVdZ9czezmyWyzpQhEbSNsHZZN0BHvxRLOYAQ7sjay8nMQwYswP6O2KlZluRMNPYefFRs+w==",
-      "dev": true,
       "optional": true
     },
     "esbuild-netbsd-64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.16.tgz",
       "integrity": "sha512-ElQ9rhdY51et6MJTWrCPbqOd/YuPowD7Cxx3ee8wlmXQQVW7UvQI6nSprJ9uVFQISqSF5e5EWpwWqXZsECLvXg==",
-      "dev": true,
       "optional": true
     },
     "esbuild-openbsd-64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.16.tgz",
       "integrity": "sha512-KgxMHyxMCT+NdLQE1zVJEsLSt2QQBAvJfmUGDmgEq8Fvjrf6vSKB00dVHUEDKcJwMID6CdgCpvYNt999tIYhqA==",
-      "dev": true,
       "optional": true
     },
     "esbuild-sunos-64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.16.tgz",
       "integrity": "sha512-exSAx8Phj7QylXHlMfIyEfNrmqnLxFqLxdQF6MBHPdHAjT7fsKaX6XIJn+aQEFiOcE4X8e7VvdMCJ+WDZxjSRQ==",
-      "dev": true,
       "optional": true
     },
     "esbuild-windows-32": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.16.tgz",
       "integrity": "sha512-zQgWpY5pUCSTOwqKQ6/vOCJfRssTvxFuEkpB4f2VUGPBpdddZfdj8hbZuFRdZRPIVHvN7juGcpgCA/XCF37mAQ==",
-      "dev": true,
       "optional": true
     },
     "esbuild-windows-64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.16.tgz",
       "integrity": "sha512-HjW1hHRLSncnM3MBCP7iquatHVJq9l0S2xxsHHj4yzf4nm9TU4Z7k4NkeMlD/dHQ4jPlQQhwcMvwbJiOefSuZw==",
-      "dev": true,
       "optional": true
     },
     "esbuild-windows-arm64": {
       "version": "0.15.16",
       "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.16.tgz",
       "integrity": "sha512-oCcUKrJaMn04Vxy9Ekd8x23O8LoU01+4NOkQ2iBToKgnGj5eo1vU9i27NQZ9qC8NFZgnQQZg5oZWAejmbsppNA==",
-      "dev": true,
       "optional": true
     },
     "escalade": {
@@ -25580,7 +25526,6 @@
       "version": "0.26.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
       "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
-      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.8"
       }
@@ -28740,7 +28685,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.4.tgz",
       "integrity": "sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==",
-      "dev": true,
       "requires": {
         "esbuild": "^0.15.9",
         "fsevents": "~2.3.2",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -15,7 +15,9 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "vite": "^3.2.3",
+    "@vitejs/plugin-react": "^2.2.0"
   },
   "devDependencies": {
     "eslint": "^8.11.0",
@@ -32,9 +34,7 @@
     "@types/node": "^18.8.3",
     "@types/react": "^18.0.24",
     "@types/react-dom": "^18.0.8",
-    "@vitejs/plugin-react": "^2.2.0",
     "typescript": "^4.6.4",
-    "vite": "^3.2.3",
     "prettier": "2.7.1"
   }
 }


### PR DESCRIPTION
Vite and @vitejs/plugin-react is required dependencies for Studio to work so they should not be in devDep

Note: there is some issue with tsconfig linking to the top level tsconfig.base.json and default import issue with react-dom/client when doing npm pack in a separate repo. But I will make a new item for that.

TEST=manual

ran `npm pack` and installed studio in another repo. See that running studio command no longer show errors for not finding vite and  @vitejs/plugin-react
<img width="763" alt="Screen Shot 2022-11-30 at 2 01 51 PM" src="https://user-images.githubusercontent.com/36055303/204885636-9d191173-c6f5-474a-a16e-48235315ee77.png">
