### PR TITLE
chore: add BSD-3 License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The Studio files listed in this repository are licensed under the below license. All other features and products are subject to separate agreements.
+
 Contains information from the language-subtag-registry JSON Database (https://github.com/mattcg/language-subtag-registry/tree/master/data/json)
 which is made available under the ODC Attribution License (https://github.com/mattcg/language-subtag-registry/blob/master/LICENSE.md).
 


### PR DESCRIPTION
Confirmed with Brian Kimmelblatt (Legal) that BSD-3 is what we should use. I copied the license from search-ui-react, which also had a preamble about needing to pay for Yext for some functionality. I left [this part](https://github.com/yext/search-ui-react/blob/main/LICENSE#L2) out as the project won't have that requirement.

J=SLAP-2493
TEST=none