### PR TITLE
fix issues when using studio outside of monorepo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20907,7 +20907,7 @@
         "webpack": "^5.75.0"
       },
       "peerDependencies": {
-        "vite": "^3.2.3"
+        "vite": "^4.0.1"
       }
     },
     "packages/studio-plugin/node_modules/@esbuild/android-arm": {
@@ -28211,7 +28211,7 @@
         "@rollup/plugin-typescript": "^10.0.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
-        "@testing-library/user-event": "*",
+        "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^29.2.4",
         "@types/node": "^18.11.15",
         "@types/react": "^18.0.26",

--- a/packages/studio-plugin/package.json
+++ b/packages/studio-plugin/package.json
@@ -30,7 +30,7 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "vite": "^3.2.3"
+    "vite": "^4.0.1"
   },
   "devDependencies": {
     "@types/jest": "^29.2.4",

--- a/packages/studio/tsconfig.json
+++ b/packages/studio/tsconfig.json
@@ -1,7 +1,18 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noImplicitAny": false,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "jsx": "react-jsx",
+    "target": "ESNext",
     "outDir": "lib",
     "types": [
       "node",

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -1,11 +1,16 @@
-import { ConfigEnv, defineConfig, PluginOption } from "vite";
+import { ConfigEnv, defineConfig, PluginOption, UserConfig } from "vite";
 import createStudioPlugin from "@yext/studio-plugin";
 import react from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
 
-export default defineConfig(async (args: ConfigEnv) => {
+export default defineConfig(async (args: ConfigEnv): Promise<UserConfig> => {
   return {
     root: __dirname,
+    build: {
+      rollupOptions: {
+        input: ["index.html", "src/store/useStudioStore.ts"]
+      }
+    },
     plugins: [react(), createStudioPlugin(args), svgr() as PluginOption],
     css: {
       postcss: __dirname,


### PR DESCRIPTION
This PR addresses two issues listed in the [item](https://yexttest.atlassian.net/browse/SLAP-2503) when using studio package outside of the monorepo:

1. tsconfig issue
    1. Context: the tsconfig in studio package extends the top level tsconfig.json. This top level file is not included in the lib build of the studio package, which results in an error. Unlike studio-plugin which only use its tsconfig to build lib/, studio's tsconfig is actively use by vite when user invoke the studio command.
    2. Potential solutions: 1) make a new package for shared tsconfig, as [suggested by turborepo](https://turbo.build/repo/docs/handbook/linting/typescript#sharing-tsconfigjson) but this would require us to publish/manage an additional package, 2) create a script to add in top level config to the package lib and modify the `extends` filepath but this feels too hacky as we would manually tamper with the lib output, or 3) remove the extends. In this PR, I decided it would be easiest to port the top level tsconfig into studio’s tsconfig without the extend to avoid this issue.

2. Vite import issues with studio’s dependencies:
    1. Context: Vite in dev mode perform a process call “dependency pre-bundling”. Vite’s dev serve all code as native ESM so it analyze the project’s entries (index.html file by default) and convert commonJS/UMD deps to ESM. (more details in [Vite doc](https://vitejs.dev/guide/dep-pre-bundling.html#the-why)). However, when using studio outside of our monorepo, the scanner fail to detect the CJS dependencies to convert because of invalid entries. The scanner will ignore any entries from node_modules — in monorepo the path is symlinked so the real repo path is used BUT when studio is installed outside of the monorepo, its entry will be within node_modules (in vite [source code function](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/optimizer/scan.ts#L139))([GH issue](https://github.com/vitejs/vite/issues/5042))
    2. Solution: Digging into their [scanner code](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/optimizer/scan.ts#L50), I found a workaround where scanner will not perform its custom globbing (which ignore node_modules) if the input of the internal rollupOptions is explicitly specify, instead of using Vite’s entry default or optimizeDeps.entries. Lastly, scanner is buggy in detecting deps for `useStudioStore` (due to the hash attached to the file by vite -- [details here](https://github.com/yext/studio-prototype/pull/72#discussion_r1057883776)), specifically zustand's usage of use-sync-external-store/shim,  so an additional input entry is added for it. 

J=2503
TEST=manual

- see that test-site in monorepo still works as expected
- created a separate repo with a react app, run `npm pack` for studio and studio-plugin then install that into the new repo. Ran the command and see that the Vite import errors no longer appear and Studio preview display and work as expected.
  - Also verify through Vite debug logs that scanner correctly detect the cjs deps:
<img width="500" alt="Screen Shot 2022-12-22 at 3 12 41 PM" src="https://user-images.githubusercontent.com/36055303/209219544-0767f85b-05ca-495b-a91d-21c967b0fd8d.png">
<img width="500" alt="Screen Shot 2022-12-22 at 3 12 46 PM" src="https://user-images.githubusercontent.com/36055303/209219545-61f4f204-68c3-41a7-812c-fc5dee44f63c.png">
