### PR TITLE
Remove element from page

### DIFF
--- a/packages/studio-plugin/src/parsers/getStudioConfig.ts
+++ b/packages/studio-plugin/src/parsers/getStudioConfig.ts
@@ -30,7 +30,6 @@ export default async function getStudioConfig(
     return defaultConfig;
   }
 
-  const studioConfig = (await import(configFilepath))
-    .default;
+  const studioConfig = (await import(configFilepath)).default;
   return lodashMerge(defaultConfig, studioConfig);
 }

--- a/packages/studio/src/components/ActivePagePanel.tsx
+++ b/packages/studio/src/components/ActivePagePanel.tsx
@@ -35,7 +35,7 @@ export default function ActivePagePanel(): JSX.Element {
               setActivePageName(pageName);
             }
             return (
-              <div key={pageName} className="flex justify-between pb-4 ml-2">
+              <div key={pageName} className="flex justify-between pb-4 px-2">
                 <div className="flex items-center">
                   <Check className={checkClasses} />
                   <button
@@ -58,7 +58,7 @@ export default function ActivePagePanel(): JSX.Element {
 
   return (
     <div className="flex flex-col w-1/4 px-4">
-      <div className="flex flex-row font-bold py-4 justify-between items-center">
+      <div className="flex flex-row font-bold py-4 pr-2 justify-between items-center">
         Pages
         <AddPageButton />
       </div>

--- a/packages/studio/src/components/ComponentNode.tsx
+++ b/packages/studio/src/components/ComponentNode.tsx
@@ -4,6 +4,7 @@ import classNames from "classnames";
 import ComponentKindIcon from "./ComponentKindIcon";
 import { useCallback, useMemo } from "react";
 import useStudioStore from "../store/useStudioStore";
+import RemoveElementButton from "./RemoveElementButton";
 
 interface ComponentNodeProps {
   /** The ComponentState this node represents in {@link ComponentTree}. */
@@ -52,15 +53,17 @@ export default function ComponentNode(props: ComponentNodeProps): JSX.Element {
 
   return (
     <div
-      className="flex pl-2 items-center h-8 cursor-pointer hover:bg-gray-100"
+      className="flex px-2 items-center justify-between h-8 cursor-pointer hover:bg-gray-100"
       style={componentNodeStyle}
-      onClick={handleClick}
     >
-      <Vector className={vectorClassName} onClick={handleToggle} />
-      <div className="pl-2">
-        <ComponentKindIcon componentState={componentState} />
+      <div className="flex grow items-center" onClick={handleClick}>
+        <Vector className={vectorClassName} onClick={handleToggle} />
+        <div className="pl-2">
+          <ComponentKindIcon componentState={componentState} />
+        </div>
+        <span className="pl-1.5">{text}</span>
       </div>
-      <span className="pl-1.5">{text}</span>
+      <RemoveElementButton elementUUID={componentState.uuid} />
     </div>
   );
 }

--- a/packages/studio/src/components/ComponentTree.tsx
+++ b/packages/studio/src/components/ComponentTree.tsx
@@ -18,7 +18,7 @@ import ComponentNode from "./ComponentNode";
 
 const ROOT_ID = "tree-root-uuid";
 const TREE_CSS_CLASSES: Readonly<Classes> = {
-  root: "p-4",
+  root: "py-2",
   placeholder: "relative",
   listItem: "relative",
 };

--- a/packages/studio/src/components/RemoveElementButton.tsx
+++ b/packages/studio/src/components/RemoveElementButton.tsx
@@ -1,0 +1,52 @@
+import useStudioStore from "../store/useStudioStore";
+import { ReactComponent as X } from "../icons/x.svg";
+import { useCallback } from "react";
+
+interface RemoveElementButtonProps {
+  /** The uuid of the element to be removed. */
+  elementUUID: string;
+}
+
+/**
+ * Renders a button for removing an element from the component tree of the
+ * active page.
+ */
+export default function RemoveElementButton({
+  elementUUID,
+}: RemoveElementButtonProps): JSX.Element | null {
+  const [getActivePageState, setActivePageState] = useStudioStore((store) => {
+    const pages = store.pages;
+    return [pages.getActivePageState, pages.setActivePageState];
+  });
+
+  const handleClick = useCallback(() => {
+    const activePageState = getActivePageState();
+    if (!activePageState) {
+      throw new Error("Tried to remove component without active page state.");
+    }
+    const componentTree = activePageState.componentTree;
+    const parentUUID = componentTree.find(
+      (c) => c.uuid === elementUUID
+    )?.parentUUID;
+    const updatedComponentTree = componentTree
+      .filter((c) => c.uuid !== elementUUID)
+      .map((c) => {
+        const updatedParentUUID =
+          c.parentUUID === elementUUID ? parentUUID : c.parentUUID;
+        return {
+          ...c,
+          parentUUID: updatedParentUUID,
+        };
+      });
+    setActivePageState({
+      ...activePageState,
+      componentTree: updatedComponentTree,
+    });
+  }, [elementUUID, getActivePageState, setActivePageState]);
+
+  return (
+    <button onClick={handleClick} aria-label="Remove Element">
+      <X />
+    </button>
+  );
+}

--- a/packages/studio/src/store/slices/createPageSlice.ts
+++ b/packages/studio/src/store/slices/createPageSlice.ts
@@ -82,7 +82,7 @@ export const createPageSlice: SliceCreator<PageSlice> = (set, get) => {
           return;
         }
         if (
-          !pageState.componentTree.find(
+          !pageState.componentTree.some(
             (component) => component.uuid === store.activeComponentUUID
           )
         ) {

--- a/packages/studio/tests/components/AddElementButton.test.tsx
+++ b/packages/studio/tests/components/AddElementButton.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import mockStore from "../__utils__/mockStore";
 import AddElementButton from "../../src/components/AddElementButton";
 import mockActivePage from "../__utils__/mockActivePage";
 

--- a/packages/studio/tests/components/AddElementMenu.test.tsx
+++ b/packages/studio/tests/components/AddElementMenu.test.tsx
@@ -1,9 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {
-  ComponentStateKind,
-  FileMetadataKind,
-} from "@yext/studio-plugin";
+import { ComponentStateKind, FileMetadataKind } from "@yext/studio-plugin";
 import AddElementMenu from "../../src/components/AddElementMenu";
 import mockActivePage from "../__utils__/mockActivePage";
 import mockStore from "../__utils__/mockStore";

--- a/packages/studio/tests/components/RemoveElementButton.test.tsx
+++ b/packages/studio/tests/components/RemoveElementButton.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import RemoveElementButton from "../../src/components/RemoveElementButton";
+import { mockPageSliceStates } from "../__utils__/mockPageSliceState";
+import { ComponentStateKind } from "@yext/studio-plugin";
+import useStudioStore from "../../src/store/useStudioStore";
+import userEvent from "@testing-library/user-event";
+import { searchBarComponent } from "../__fixtures__/componentStates";
+
+beforeEach(() => {
+  mockPageSliceStates({
+    pages: {
+      universal: {
+        componentTree: [
+          {
+            kind: ComponentStateKind.Fragment,
+            uuid: "mock-uuid-0",
+          },
+          {
+            ...searchBarComponent,
+            uuid: "mock-uuid-1",
+            parentUUID: "mock-uuid-0",
+          },
+          {
+            ...searchBarComponent,
+            uuid: "mock-uuid-2",
+            parentUUID: "mock-uuid-1",
+          },
+          {
+            ...searchBarComponent,
+            uuid: "mock-uuid-3",
+            parentUUID: "mock-uuid-0",
+          },
+        ],
+        cssImports: [],
+        filepath: "mock-filepath",
+      },
+    },
+    activePageName: "universal",
+    activeComponentUUID: "mock-uuid-1",
+  });
+});
+
+it("removes element from component tree and updates the store", async () => {
+  const setActivePageStateSpy = jest.spyOn(
+    useStudioStore.getState().pages,
+    "setActivePageState"
+  );
+  render(<RemoveElementButton elementUUID="mock-uuid-1" />);
+  const removeElementButton = screen.getByRole("button");
+  await userEvent.click(removeElementButton);
+
+  expect(setActivePageStateSpy).toBeCalledWith({
+    componentTree: [
+      {
+        kind: ComponentStateKind.Fragment,
+        uuid: "mock-uuid-0",
+      },
+      {
+        ...searchBarComponent,
+        uuid: "mock-uuid-2",
+        parentUUID: "mock-uuid-0",
+      },
+      {
+        ...searchBarComponent,
+        uuid: "mock-uuid-3",
+        parentUUID: "mock-uuid-0",
+      },
+    ],
+    cssImports: [],
+    filepath: "mock-filepath",
+  });
+  expect(useStudioStore.getState().pages.activeComponentUUID).toBeUndefined();
+});


### PR DESCRIPTION
Add support for removing an element from a page. When a container element is removed, its direct children become the direct children of the removed element's parent.

Since there was no icon in the mocks for this action, I added an X next to each element in the tree to mimic how the remove page button looks.

J=SLAP-2529
TEST=auto, manual

In the test-site, see that top-level, container, and leaf elements can be removed and the component tree is updated as expected.