### PR TITLE
Correct logic for finding `topLevelJsxNode`.

### DIFF
--- a/packages/studio-plugin/src/parsers/ComponentTreeParser.ts
+++ b/packages/studio-plugin/src/parsers/ComponentTreeParser.ts
@@ -40,7 +40,9 @@ export default class ComponentTreeParser {
       returnStatement;
     const topLevelJsxNode = JsxNodeWrapper.getChildren().find(
       (n): n is JsxElement | JsxFragment | JsxSelfClosingElement =>
-        n.isKind(SyntaxKind.JsxElement) || n.isKind(SyntaxKind.JsxFragment) || n.isKind(SyntaxKind.JsxSelfClosingElement)
+        n.isKind(SyntaxKind.JsxElement) ||
+        n.isKind(SyntaxKind.JsxFragment) ||
+        n.isKind(SyntaxKind.JsxSelfClosingElement)
     );
     if (!topLevelJsxNode) {
       throw new Error(


### PR DESCRIPTION
The logic for finding `topLevelJsxNode` in `parseComponentTree` was not correct. Specifically, it did not allow for a `JsxSelfClosingElement` to be a top-level Node. A self-closing Element is something like: `<Banner/>`. The corresponding `JsxElement` would be `<Banner></Banner>`. Both, though, do refer to a JSX Element. It's an idiosyncracy of `ts-morph` that the two cases are labeled differently.

J=SLAP-2563
TEST=manual

Ensured that I could run Studio for a Page with a top-level `JsxSelfClosingElement`.