### PR TITLE
Run Playwright Checks on PR

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,10 @@
 name: Playwright Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
This commit updates the `playwright.yml` file so that Playwright checks are run on PRs into `main`. Previously, these checks were only run on a `push` to `main`.