### PR TITLE
Prevent Module Internals from being Highlighted in Page Mode

### DIFF
--- a/packages/studio/src/components/ComponentTreePreview.tsx
+++ b/packages/studio/src/components/ComponentTreePreview.tsx
@@ -28,6 +28,7 @@ import classNames from "classnames";
 interface ComponentTreePreviewProps {
   componentTree: ComponentState[];
   props?: PropValues;
+  isWithinModule?: boolean;
 }
 
 /**
@@ -36,9 +37,14 @@ interface ComponentTreePreviewProps {
 export default function ComponentTreePreview({
   componentTree,
   props,
+  isWithinModule,
 }: ComponentTreePreviewProps): JSX.Element {
   useImportedComponents(componentTree);
-  const elements = useComponentTreeElements(componentTree, props);
+  const elements = useComponentTreeElements(
+    componentTree,
+    props,
+    isWithinModule
+  );
   return <>{elements}</>;
 }
 
@@ -48,7 +54,8 @@ export default function ComponentTreePreview({
  */
 function useComponentTreeElements(
   componentTree: ComponentState[],
-  props?: PropValues
+  props?: PropValues,
+  isWithinModule?: boolean
 ): (JSX.Element | null)[] | null {
   const [UUIDToImportedComponent, UUIDToFileMetadata] = useStudioStore(
     (store) => [
@@ -79,6 +86,7 @@ function useComponentTreeElements(
             <ComponentTreePreview
               componentTree={metadata.componentTree}
               props={c.props}
+              isWithinModule={true}
             />
           );
         } else if (!UUIDToImportedComponent[c.metadataUUID]) {
@@ -109,6 +117,9 @@ function useComponentTreeElements(
     return ComponentTreeHelpers.mapComponentTree(
       componentTree,
       (c, children) => {
+        if (isWithinModule) {
+          return <ErrorBoundary>{renderComponent(c, children)}</ErrorBoundary>;
+        }
         return (
           <HighlightingContainer key={c.uuid} uuid={c.uuid}>
             <ErrorBoundary>{renderComponent(c, children)}</ErrorBoundary>
@@ -121,6 +132,7 @@ function useComponentTreeElements(
     UUIDToImportedComponent,
     expressionSources,
     componentTree,
+    isWithinModule,
   ]);
 }
 


### PR DESCRIPTION
This PR prevents the internals of a module from receiving active component highlighting while in page mode.
There is no point of highlighting the internals of a module when the module is not currently being edited,
instead clicking on the internals of a module should highlight the module itself.

Allowing the internals of a module to be highlighted will also result in multiple components on the page being highlighted
at once, if there are multiple copies of the module on the page. This is because multiple copies of the same module
will result in multiple copies of the same internal components, which share the same ComponentState.uuid.
This behavior is likely undesired.

J=none
TEST=manual

see that if I click inside a module in the preview, the module will be highlighted, not any of the components WITHIN
the module
if I click inside a module while it's being edited, the internal components still show up as highlighted