### PR TITLE
Fix Modal being Blocked 

### DIFF
--- a/packages/studio/src/components/common/Modal.tsx
+++ b/packages/studio/src/components/common/Modal.tsx
@@ -24,8 +24,8 @@ const customReactModalStyles = {
     transform: "translate(-50%, -50%)",
   },
   overlay: {
-    zIndex: 1000
-  }
+    zIndex: 1000,
+  },
 };
 
 export default function Modal({


### PR DESCRIPTION
Increases the modal overlay's z-index to 1000 so it doesn't get blocked by the page itself.

J=none
TEST=manual

can click on the modal again for creating modules