### PR TITLE
Remove console warnings and errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21547,21 +21547,6 @@
         "commander": "^9.4.1"
       }
     },
-    "node_modules/zundo": {
-      "version": "2.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/zundo/-/zundo-2.0.0-beta.8.tgz",
-      "integrity": "sha512-J88U4ApZc+utZC8/y/b6fR/J8obxjMYq/0ZhpDkmUp/x7tCr9juITa0iBMJAhRB/yLAP4oHJh9gaZmAdsBu1JA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/charkour"
-      },
-      "peerDependencies": {
-        "zustand": "^4.1.0"
-      }
-    },
     "node_modules/zustand": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.2.tgz",
@@ -21597,7 +21582,7 @@
     },
     "packages/studio": {
       "name": "@yext/studio",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@dhmk/zustand-lens": "^2.0.5",
         "@minoru/react-dnd-treeview": "^3.4.1",
@@ -21616,8 +21601,8 @@
         "tailwindcss": "^3.2.4",
         "vite": "^4.0.4",
         "vite-plugin-svgr": "^2.4.0",
-        "zundo": "2.0.0-beta.8",
-        "zustand": "^4.2.0"
+        "zundo": "2.0.0-beta.10",
+        "zustand": "^4.3.2"
       },
       "bin": {
         "studio": "lib/bin/studio.js"
@@ -21699,6 +21684,21 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "packages/studio/node_modules/zundo": {
+      "version": "2.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/zundo/-/zundo-2.0.0-beta.10.tgz",
+      "integrity": "sha512-0AlWe9p1Wrw+Z9vcr5diPex3E2n5gzCWa0MzEWy+HREdFpgLaZ/Jj4O7f+8sOkjmjYrP5n/vCNtBJ1HNqHT9xw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/charkour"
+      },
+      "peerDependencies": {
+        "zustand": "^4.3.0"
       }
     },
     "plugins/sample-component": {

--- a/packages/studio/__mocks__/zustand.ts
+++ b/packages/studio/__mocks__/zustand.ts
@@ -8,7 +8,7 @@
 import { act } from "react-dom/test-utils";
 import * as registerMessageListenerModule from "../src/messaging/registerMessageListener";
 import { MessageIdToListeners } from "../tests/__setup__/setup-env";
-const actualCreate = jest.requireActual("zustand");
+const { create: actualCreate } = jest.requireActual("zustand");
 
 // track message listeners registered on store creation
 export const storeRegisteredListeners: MessageIdToListeners = {};
@@ -16,35 +16,44 @@ export const storeRegisteredListeners: MessageIdToListeners = {};
 // a variable to hold reset functions for all stores declared in the app
 const storeResetFns = new Set<() => void>();
 
-// when creating a store, we add a reset function for it in the set
+// when creating a store, we get its initial state, create a reset function and
+// add it in the set
+export const create = () => (createState: unknown) => {
+  const spy = jest.spyOn(registerMessageListenerModule, "default");
+  const store = actualCreate(createState);
+  // On store creation, save all the store's message listeners.
+  spy.mock.calls.forEach(([messageID, cb]) => {
+    const listeners = storeRegisteredListeners[messageID];
+    if (listeners) {
+      listeners.push(cb);
+    }
+    storeRegisteredListeners[messageID] = [cb];
+  });
+  const initialState = store.getState();
+  storeResetFns.add(() => store.setState(initialState, true));
+  return store;
+};
+
+// createStore is adapted from
+// https://github.com/charkour/zundo/blob/main/packages/zundo/__mocks__/zustand/index.js
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const create = (temporalStore?: any) => {
-  if (temporalStore) {
-    const { clear } = temporalStore.getState();
-    storeResetFns.add(clear);
-    return temporalStore.getState;
-  } else {
-    return (createState: unknown) => {
-      const spy = jest.spyOn(registerMessageListenerModule, "default");
-      const store = actualCreate(createState);
-      // On store creation, save all the store's message listeners.
-      spy.mock.calls.forEach(([messageID, cb]) => {
-        const listeners = storeRegisteredListeners[messageID];
-        if (listeners) {
-          listeners.push(cb);
-        }
-        storeRegisteredListeners[messageID] = [cb];
-      });
-      const initialState = store.getState();
-      storeResetFns.add(() => store.setState(initialState, true));
-      return store;
-    };
+export const createStore = (createState?: any) => {
+  if (!createState) {
+    return createStore;
   }
+  const store = actualCreate(createState);
+  const initialState = store.getState();
+  storeResetFns.add(() => store.setState(initialState, true));
+  return store;
+};
+
+export const useStore = (temporalStore) => {
+  const { clear } = temporalStore.getState();
+  storeResetFns.add(clear);
+  return temporalStore.getState();
 };
 
 // Reset all stores after each test run
 beforeEach(() => {
   act(() => storeResetFns.forEach((resetFn) => resetFn()));
 });
-
-export default create;

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/studio",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "types": "./lib/types.d.ts",
   "bin": {
     "studio": "./lib/bin/studio.js"
@@ -29,8 +29,8 @@
     "tailwindcss": "^3.2.4",
     "vite": "^4.0.4",
     "vite-plugin-svgr": "^2.4.0",
-    "zundo": "2.0.0-beta.8",
-    "zustand": "^4.2.0"
+    "zundo": "2.0.0-beta.10",
+    "zustand": "^4.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.5",

--- a/packages/studio/src/components/ComponentTreePreview.tsx
+++ b/packages/studio/src/components/ComponentTreePreview.tsx
@@ -15,6 +15,7 @@ import {
   FileMetadataKind,
   PropValues,
   ComponentState,
+  transformPropValuesToRaw,
 } from "@yext/studio-plugin";
 import { ImportType } from "../store/models/ImportType";
 import { useLayoutEffect } from "react";
@@ -22,7 +23,6 @@ import { getPreviewProps } from "../utils/getPreviewProps";
 import ErrorBoundary from "./common/ErrorBoundary";
 import useImportedComponents from "../hooks/useImportedComponents";
 import initialStudioData from "virtual:yext-studio";
-import { transformPropValuesToRaw } from "@yext/studio-plugin";
 import classNames from "classnames";
 
 interface ComponentTreePreviewProps {
@@ -87,6 +87,7 @@ function useComponentTreeElements(
               componentTree={metadata.componentTree}
               props={c.props}
               isWithinModule={true}
+              key={c.uuid}
             />
           );
         } else if (!UUIDToImportedComponent[c.metadataUUID]) {
@@ -118,7 +119,11 @@ function useComponentTreeElements(
       componentTree,
       (c, children) => {
         if (isWithinModule) {
-          return <ErrorBoundary>{renderComponent(c, children)}</ErrorBoundary>;
+          return (
+            <ErrorBoundary key={c.uuid}>
+              {renderComponent(c, children)}
+            </ErrorBoundary>
+          );
         }
         return (
           <HighlightingContainer key={c.uuid} uuid={c.uuid}>

--- a/packages/studio/src/store/useStudioStore.ts
+++ b/packages/studio/src/store/useStudioStore.ts
@@ -1,4 +1,4 @@
-import create, { StateCreator } from "zustand";
+import { create, StateCreator } from "zustand";
 import { withLenses, lens } from "@dhmk/zustand-lens";
 import { immer } from "zustand/middleware/immer";
 import { enableMapSet } from "immer";

--- a/packages/studio/src/store/useTemporalStore.ts
+++ b/packages/studio/src/store/useTemporalStore.ts
@@ -1,4 +1,4 @@
-import create from "zustand";
+import { useStore } from "zustand";
 import useStudioStore from "./useStudioStore";
 
 /**
@@ -6,6 +6,8 @@ import useStudioStore from "./useStudioStore";
  * future versions of the store and provides actions for navigating between
  * them (`undo()` and `redo()`) and clearing the history (`clear()`).
  */
-const useTemporalStore = create(useStudioStore.temporal);
+function useTemporalStore() {
+  return useStore(useStudioStore.temporal);
+}
 
 export default useTemporalStore;


### PR DESCRIPTION
This PR addresses
- A console error about needing to specify unique keys that occurred when there were multiple components in a tree, at least one of which is a module
- 4 console warnings about various `zustand` exports being deprecated, particularly the default export. A couple of these were coming from within `zundo`, but were fixed in its latest version
<img width="589" alt="Screen Shot 2023-02-03 at 2 19 31 PM" src="https://user-images.githubusercontent.com/88398086/216688967-b0b6be7e-a47e-44f7-bc65-a4a0b8c32ba3.png">

J=SLAP-2578
TEST=manual

See that the regular store and undo/redo still work as expected and that multiple components, including a module, can be displayed on a page without console errors or warnings related to `zustand`.