### PR TITLE
Remove optimizeDeps.include

### DIFF
--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -30,17 +30,5 @@ export default defineConfig(async (args: ConfigEnv): Promise<UserConfig> => {
     css: {
       postcss: __dirname,
     },
-    optimizeDeps: {
-      include: [
-        "recent-searches",
-        "hashlru",
-        "lodash/isEqual",
-        "prop-types",
-        "react-dom",
-        "raf",
-        "cross-fetch",
-        "mapbox-gl",
-      ],
-    },
   };
 });


### PR DESCRIPTION
These were originally added as a temporary way for the search-ui-react external components to function for the bug bash.
However when the search-ui-react dependencies are not present in the repo vite will give warnings on startup
about not being able to find certain dependencies.

I think for now we should remove this field, and in the future update our external components logic to
support components with cjs dependencies (which I would guess a large portion useful components).

J=none
TEST=manual

can still start studio