### PR TITLE
Fix bugs in previewing module props

### DIFF
--- a/apps/test-site/src/modules/ContainerWithButtons.tsx
+++ b/apps/test-site/src/modules/ContainerWithButtons.tsx
@@ -2,12 +2,21 @@ import Banner from "../components/Banner";
 import Button from "../components/Button";
 import Container from "../components/Container";
 
-export default function ContainerWithButtons() {
+export interface ContainerWithButtonsProps {
+  bannerNum?: number;
+}
+
+export default function ContainerWithButtons(props: ContainerWithButtonsProps) {
   return (
     <Container>
       <Button />
       <Button />
-      <Banner bgColor="#FFFFFF" bool={false} num={0} title="asdfasdffd" />
+      <Banner
+        bgColor="#FFFFFF"
+        bool={false}
+        num={props.bannerNum}
+        title="asdfasdffd"
+      />
       <Container>
         <Banner bgColor="#abcdef" num={5} bool={true} title="initial title" />
       </Container>

--- a/apps/test-site/src/pages/UniversalPage.tsx
+++ b/apps/test-site/src/pages/UniversalPage.tsx
@@ -3,6 +3,7 @@ import Banner from "../components/Banner";
 import Button from "../components/Button";
 import Container from "../components/Container";
 import ContainerWithButtons from "../modules/ContainerWithButtons";
+import siteSettings from "../siteSettings";
 
 export default function UniversalPage() {
   return (
@@ -12,7 +13,7 @@ export default function UniversalPage() {
         <Button bgColor="bg-red-100" />
       </Container>
       <AceComponent text="ace" />
-      <ContainerWithButtons />
+      <ContainerWithButtons bannerNum={siteSettings.someNum} />
       <Banner nestedProp={{ egg: "eggyweggy" }} />
     </div>
   );

--- a/apps/test-site/src/siteSettings.ts
+++ b/apps/test-site/src/siteSettings.ts
@@ -1,6 +1,7 @@
 import { HexColor } from "@yext/studio";
 
 export interface SiteSettings {
+  someNum: number;
   experienceKey: string;
   optionalString?: string;
   "Global Colors": {
@@ -9,6 +10,7 @@ export interface SiteSettings {
 }
 
 export default {
+  someNum: 12,
   experienceKey: "slanswers",
   "Global Colors": {
     primary: "#AABBCC",

--- a/packages/studio-plugin/src/writers/ReactComponentFileWriter.ts
+++ b/packages/studio-plugin/src/writers/ReactComponentFileWriter.ts
@@ -179,7 +179,6 @@ export default class ReactComponentFileWriter {
         this.updatePropInterface(propShape);
         this.studioSourceFileWriter.updateFunctionParameter(
           functionComponent,
-          Object.keys(propShape),
           `${this.componentName}Props`
         );
       }

--- a/packages/studio-plugin/src/writers/StreamConfigWriter.ts
+++ b/packages/studio-plugin/src/writers/StreamConfigWriter.ts
@@ -163,8 +163,8 @@ export default class StreamConfigWriter {
   addStreamParameter(componentFunction: FunctionDeclaration | ArrowFunction) {
     this.studioSourceFileWriter.updateFunctionParameter(
       componentFunction,
-      ["document"],
-      STREAM_PAGE_PROPS_TYPE
+      STREAM_PAGE_PROPS_TYPE,
+      ["document"]
     );
   }
 }

--- a/packages/studio-plugin/src/writers/StudioSourceFileWriter.ts
+++ b/packages/studio-plugin/src/writers/StudioSourceFileWriter.ts
@@ -159,23 +159,24 @@ export default class StudioSourceFileWriter {
   /**
    * Update the function's parameter by removing the existing parameter
    * at the specified index, if any, and insert a new parameter with
-   * the provided content in the form of ObjectBindingPattern
-   * (e.g. \{ x, y \}: PropsType).
+   * the provided content. If props are passed in, the content is in the
+   * form of ObjectBindingPattern (e.g. \{ x, y \}: PropsType).
+   * Otherwise, it is in the form of `props: PropsType`.
    *
    * @param functionNode - the function node to modify the parameter
-   * @param props - the props to display in the ObjectBindingPattern
    * @param type - the type of the parameter
+   * @param props - the props to display in the ObjectBindingPattern
    * @param index - the index of the parameter to update or insert
    */
   updateFunctionParameter(
     functionNode: FunctionDeclaration | ArrowFunction,
-    props: string[],
     type: string,
+    props?: string[],
     index = 0
   ): void {
     functionNode.getParameters()[index]?.remove();
     functionNode.insertParameter(index, {
-      name: `{ ${props.join(", ")} }`,
+      name: props ? `{ ${props.join(", ")} }` : "props",
       type,
     });
   }

--- a/packages/studio-plugin/tests/__fixtures__/ModuleFile/updateModuleFile/ModuleWithInitialProps.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/ModuleFile/updateModuleFile/ModuleWithInitialProps.tsx
@@ -9,6 +9,6 @@ export const initialProps: PanelProps = {
   complexBannerText: "Hello world!",
 };
 
-export default function Panel({ complexBannerText }: PanelProps) {
+export default function Panel(props: PanelProps) {
   return <ComplexBanner />;
 }

--- a/packages/studio-plugin/tests/__fixtures__/ModuleFile/updateModuleFile/ModuleWithInitialPropsMultiFields.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/ModuleFile/updateModuleFile/ModuleWithInitialPropsMultiFields.tsx
@@ -12,9 +12,6 @@ export const initialProps: PanelProps = {
   complexBannerBool: true,
 };
 
-export default function Panel({
-  complexBannerText,
-  complexBannerBool,
-}: PanelProps) {
+export default function Panel(props: PanelProps) {
   return <ComplexBanner />;
 }

--- a/packages/studio-plugin/tests/__fixtures__/ModuleFile/updateModuleFile/ModuleWithPropShape.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/ModuleFile/updateModuleFile/ModuleWithPropShape.tsx
@@ -5,6 +5,6 @@ export interface PanelProps {
   complexBannerText?: string;
 }
 
-export default function Panel({ complexBannerText }: PanelProps) {
+export default function Panel(props: PanelProps) {
   return <ComplexBanner />;
 }

--- a/packages/studio-plugin/tests/__fixtures__/ModuleFile/updateModuleFile/ModuleWithPropShapeMultiFields.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/ModuleFile/updateModuleFile/ModuleWithPropShapeMultiFields.tsx
@@ -7,9 +7,6 @@ export interface PanelProps {
   complexBannerBool?: boolean;
 }
 
-export default function Panel({
-  complexBannerText,
-  complexBannerBool,
-}: PanelProps) {
+export default function Panel(props: PanelProps) {
   return <ComplexBanner />;
 }

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -6,9 +6,17 @@ import ActionsBar from "./components/ActionsBar";
 import Toast from "./components/Toast";
 
 export default function App() {
-  const componentTree = useStudioStore((store) =>
-    store.actions.getComponentTree()
-  );
+  const [componentTree, getModuleStateBeingEdited, UUIDToFileMetadata] =
+    useStudioStore((store) => [
+      store.actions.getComponentTree(),
+      store.pages.getModuleStateBeingEdited,
+      store.fileMetadatas.UUIDToFileMetadata,
+    ]);
+  const moduleStateBeingEdited = getModuleStateBeingEdited();
+  const props = moduleStateBeingEdited?.props;
+  const propShape =
+    moduleStateBeingEdited &&
+    UUIDToFileMetadata[moduleStateBeingEdited.metadataUUID].propShape;
 
   return (
     <div className="App">
@@ -19,7 +27,11 @@ export default function App() {
           <ActivePagePanel />
           <div className="grow w-1/3 bg-gray-300">
             {componentTree && (
-              <ComponentTreePreview componentTree={componentTree} />
+              <ComponentTreePreview
+                componentTree={componentTree}
+                props={props}
+                propShape={propShape}
+              />
             )}
           </div>
           <EditorPanel />

--- a/packages/studio/tests/components/ComponentTreePreview.test.tsx
+++ b/packages/studio/tests/components/ComponentTreePreview.test.tsx
@@ -217,6 +217,19 @@ const mockStoreWithPropExpression: MockStudioStore = {
             uuid: "banner-uuid",
             metadataUUID: "banner-metadata-uuid",
           },
+          {
+            kind: ComponentStateKind.Module,
+            componentName: "Panel",
+            props: {
+              text: {
+                kind: PropValueKind.Expression,
+                value: "siteSettings.someText",
+                valueType: PropValueType.string,
+              },
+            },
+            uuid: "panel-uuid",
+            metadataUUID: "panel-metadata-uuid",
+          },
         ],
         cssImports: [],
         entityFiles: ["entityFile.json"],
@@ -227,13 +240,21 @@ const mockStoreWithPropExpression: MockStudioStore = {
     activeEntityFile: "entityFile.json",
   },
   fileMetadatas: {
-    UUIDToFileMetadata,
+    UUIDToFileMetadata: {
+      ...UUIDToFileMetadata,
+      "panel-metadata-uuid": moduleMetadata,
+    },
   },
   siteSettings: {
     values: {
       apiKey: {
         kind: PropValueKind.Literal,
         value: "mock-api-key",
+        valueType: PropValueType.string,
+      },
+      someText: {
+        kind: PropValueKind.Literal,
+        value: "mock-text",
         valueType: PropValueType.string,
       },
     },
@@ -285,6 +306,8 @@ it("renders component with transformed props", async () => {
   expect(siteSettingsExpressionProp).toBeDefined();
   const documentExpressionProp = await screen.findByText(/123/);
   expect(documentExpressionProp).toBeDefined();
+  const moduleExpressionProp = await screen.findByText(/mock-text/);
+  expect(moduleExpressionProp).toBeDefined();
 });
 
 it("can render component using nested siteSettings expression", async () => {


### PR DESCRIPTION
This PR fixes a couple bugs related to previewing props for modules:
- When a module was being edited we weren't allowing its props to be used as an expression source for previewing props, so `props.blah` previews that worked when editing at the page-level would stop working when trying to edit at the module-level
- If a page was passing a module a prop (e.g. `myProp`) with an expression for the prop value (e.g. `myProp: siteSettings.blah`), the value was not being extracted correctly for previewing props within the module that used that prop as an expression (e.g. `props.myProp`). It was being treated as a string literal
- When writing module files, we were destructuring the props even though the UI expects them to be specified as `props.blah` rather than `blah` directly

Also, updated `useExpressionSources` so that components within a module can't access `document` fields, since that's currently not supported (see [item](https://yexttest.atlassian.net/browse/SLAP-2598)).

J=SLAP-2616
TEST=auto, manual

Updated the test-site so it checks that expression prop values can be passed from a page to a module to a component inside the module, can be previewed properly both when editing on the page-level and module-level, and that write-to-file generates a module file without TS errors.