### PR TITLE
Styling Improvements for the Component Tree.

### DIFF
--- a/packages/studio/src/components/ComponentNode.tsx
+++ b/packages/studio/src/components/ComponentNode.tsx
@@ -41,7 +41,8 @@ export default function ComponentNode(props: ComponentNodeProps): JSX.Element {
     return componentState.componentName;
   };
 
-  const isActiveComponent = (): boolean => activeComponentUUID === componentState.uuid;
+  const isActiveComponent = (): boolean =>
+    activeComponentUUID === componentState.uuid;
 
   const vectorClassName = classNames("cursor-pointer", {
     "rotate-90": isOpen,


### PR DESCRIPTION
This PR makes a few improvements to the styling of the `ComponentNode` class. 
- Padding was slightly tweaked. 
- The gray background of the Hover state now fits the width of the `ComponentTree` container.
- The Remove button is only shown for the active Component. 

J=SLAP-2612
TEST=manual