### PR TITLE
Add Border and Shadow to Page Preview.

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -12,7 +12,7 @@ export default function App() {
         <ActionsBar />
         <div className="flex flex-row grow">
           <ActivePagePanel />
-          <div className="grow w-1/3 bg-gray-300">
+          <div className="grow w-1/3 bg-white border-8 shadow">
             <HighlightedPreview />
           </div>
           <EditorSidebar />


### PR DESCRIPTION
This PR adds a Border and Shadow to the `HighlightedPreview`. This provides better deliniation between what's in Studio and the actual Page. Max also asked that the background color of the Preview be changed to White.

TEST=manual

Ensured that the Active Component Highlighting boundary boxes are still correct.