### PR TITLE
Set host and port when invoking Vite.

### DIFF
--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -13,6 +13,8 @@ export default defineConfig(async (args: ConfigEnv): Promise<UserConfig> => {
   return {
     root: __dirname,
     server: {
+      host: "0.0.0.0",
+      port: 5173,
       fs: {
         allow: [
           searchForWorkspaceRoot(process.cwd()),


### PR DESCRIPTION
The `host` and `port` options are now declared explicitly in the Vite Config. This enables port-forwarding of Studio to work in GH Codespaces. Without the port forwarding, users cannot see Studio in the Codespace. I verified this does not impact local development at all. 

J=SLAP-2649
TEST=auto, manual

Ensured all automated tests passed. Spun up Studio locally and ensured I could still modify props, add/remove Components, and that Save produced the expected file changes. 