### PR TITLE
Begin adding test coverage for `GitWrapper`.

### DIFF
--- a/packages/studio-plugin/src/createStudioPlugin.ts
+++ b/packages/studio-plugin/src/createStudioPlugin.ts
@@ -1,4 +1,5 @@
 import { ConfigEnv, Plugin } from "vite";
+import { simpleGit } from "simple-git";
 import getStudioConfig from "./parsers/getStudioConfig";
 import ParsingOrchestrator, {
   createTsMorphProject,
@@ -25,7 +26,7 @@ export default async function createStudioPlugin(
     .default;
   const pathToUserProjectRoot = process.cwd();
   const studioConfig = await getStudioConfig(pathToUserProjectRoot);
-  const gitWrapper = new GitWrapper();
+  const gitWrapper = new GitWrapper(simpleGit());
   await gitWrapper.refreshData();
 
   /** The ts-morph Project instance for the entire app. */

--- a/packages/studio-plugin/src/git/GitWrapper.ts
+++ b/packages/studio-plugin/src/git/GitWrapper.ts
@@ -1,12 +1,12 @@
-import { SimpleGit, simpleGit } from "simple-git";
+import { SimpleGit } from "simple-git";
 import { GitData } from "../types";
 
 export default class GitWrapper {
   private git: SimpleGit;
   private gitData?: GitData;
 
-  constructor() {
-    this.git = simpleGit();
+  constructor(git: SimpleGit) {
+    this.git = git;
   }
 
   async deploy() {

--- a/packages/studio-plugin/tests/git/GitWrapper.test.ts
+++ b/packages/studio-plugin/tests/git/GitWrapper.test.ts
@@ -1,0 +1,28 @@
+import { simpleGit } from "simple-git";
+import GitWrapper from "../../src/git/GitWrapper";
+
+jest.mock("simple-git", () => {
+  return {
+    simpleGit: () => {
+      return {
+        add: jest.fn(),
+        commit: jest.fn(),
+        push: jest.fn(),
+      };
+    },
+  };
+});
+const mockedGitInstance = simpleGit();
+const gitAddSpy = jest.spyOn(mockedGitInstance, "add");
+const gitCommitSpy = jest.spyOn(mockedGitInstance, "commit");
+const gitPushSpy = jest.spyOn(mockedGitInstance, "push");
+
+const gitWrapper = new GitWrapper(mockedGitInstance);
+
+it("invokes Git commands correctly on deploy", async () => {
+  await gitWrapper.deploy();
+
+  expect(gitAddSpy).toBeCalledWith("-A");
+  expect(gitCommitSpy).toBeCalledWith("Yext Studio Commit");
+  expect(gitPushSpy).toBeCalled();
+});


### PR DESCRIPTION
This PR adds the first unit test for the `GitWrapper` class. A subsequent PR will test the various cases for the `canPush` method. Looking at the coverage report, this class had one of the biggest gaps in coverage.

TEST=auto