### PR TITLE
Ensure de-duplication when generating `fields` for the `TemplateConfig`.

### DIFF
--- a/packages/studio-plugin/src/utils/StreamConfigFieldsMerger.ts
+++ b/packages/studio-plugin/src/utils/StreamConfigFieldsMerger.ts
@@ -37,13 +37,12 @@ const pagesJSFieldsMerger: StreamConfigFieldsMerger = (
   existingFields: string[],
   newFields: string[]
 ): string[] => {
-  let mergedFields = newFields.filter(
+  const mergedFields = newFields.filter(
     (documentPath) => !NON_CONFIGURABLE_STREAM_PROPERTIES.includes(documentPath)
   );
   existingFields.includes("slug") && mergedFields.push("slug");
-  mergedFields = [...new Set(mergedFields)];
 
-  return mergedFields;
+  return [...new Set(mergedFields)];
 };
 
 export default pagesJSFieldsMerger;

--- a/packages/studio-plugin/src/writers/StreamConfigWriter.ts
+++ b/packages/studio-plugin/src/writers/StreamConfigWriter.ts
@@ -92,8 +92,10 @@ export default class StreamConfigWriter {
 
     const currentFields = currentTemplateConfig?.stream?.fields || [];
     const newFields = [...usedDocumentPaths]
-      // Stream config's fields do not allow specifying an index of a field.
-      .map((documentPath) => documentPath.split("document.")[1].split("[")[0]);
+      // Stream config's fields do not allow specifying an index or sub-field of a field.
+      .map((documentPath) => /^document\.([^[.]+)/.exec(documentPath))
+      .filter((matchResults) => matchResults && matchResults.length >= 2)
+      .map((matchResults) => (matchResults as RegExpExecArray)[1]);
 
     return {
       ...currentTemplateConfig,

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithStreamConfigArrayAndObjectField.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithStreamConfigArrayAndObjectField.tsx
@@ -6,7 +6,7 @@ export const config: TemplateConfig = {
     $id: "studio-stream-id",
     filter: {},
     localization: { locales: ["en"], primary: false },
-    fields: ["arrayIndex"],
+    fields: ["arrayIndex", "objectField"],
   },
 };
 
@@ -15,6 +15,8 @@ export default function IndexPage({ document }: TemplateProps) {
     <>
       <ComplexBanner title={document.arrayIndex[0]} />
       <ComplexBanner title={document.arrayIndex[1]} />
+      <ComplexBanner title={document.objectField.attr1} />
+      <ComplexBanner title={document.objectField.attr2} />
     </>
   );
 }

--- a/packages/studio-plugin/tests/sourcefiles/PageFile.updatePageFile.test.ts
+++ b/packages/studio-plugin/tests/sourcefiles/PageFile.updatePageFile.test.ts
@@ -230,6 +230,32 @@ describe("updatePageFile", () => {
               },
               metadataUUID: "mock-metadata-uuid-1",
             },
+            {
+              kind: ComponentStateKind.Standard,
+              componentName: "ComplexBanner",
+              uuid: "mock-uuid-2",
+              props: {
+                title: {
+                  kind: PropValueKind.Expression,
+                  value: "document.objectField.attr1",
+                  valueType: PropValueType.string,
+                },
+              },
+              metadataUUID: "mock-metadata-uuid-2",
+            },
+            {
+              kind: ComponentStateKind.Standard,
+              componentName: "ComplexBanner",
+              uuid: "mock-uuid-3",
+              props: {
+                title: {
+                  kind: PropValueKind.Expression,
+                  value: "document.objectField.attr2",
+                  valueType: PropValueType.string,
+                },
+              },
+              metadataUUID: "mock-metadata-uuid-3",
+            },
           ],
           cssImports: [],
           filepath: "mock-filepath",
@@ -239,7 +265,7 @@ describe("updatePageFile", () => {
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         expect.stringContaining("PageWithStreamConfigMultipleFields.tsx"),
         fs.readFileSync(
-          getPagePath("updatePageFile/PageWithStreamConfigArrayField"),
+          getPagePath("updatePageFile/PageWithStreamConfigArrayAndObjectField"),
           "utf-8"
         )
       );


### PR DESCRIPTION
This PR adds de-duplication logic to the `pagesJSFieldsMerger`. This ensures that Studio always generates a unique set of `fields`, no field appears twice. This issue came to light because someone was using two different elements of an array field on their page as props. This resulted in the array field appearing twice in `fields` whenever they saved.

TEST=auto

Added a test for the exact scenario the customer ran into. The test ensures we are de-duping properly.