### PR TITLE
Create `ParsingError` type and add preliminary usages

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,6 +7,7 @@ module.exports = {
     "packages/studio-plugin/tests/__fixtures__/**/*.tsx",
     ".eslintrc.cjs",
     "**/coverage",
+    "*.d.ts",
   ],
   parserOptions: {
     project: ["tsconfig.json"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -20022,6 +20022,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/true-myth": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/true-myth/-/true-myth-6.2.0.tgz",
+      "integrity": "sha512-NYvzj/h2mGXmdIBmz825c/lQhpI4bzUQEEiBCAbNOVpr6aeYa1WTpJ+OmGmj1yPqbTLPKCCSi54yDnaEup504Q==",
+      "engines": {
+        "node": "14.* || 16.* || >= 18.*"
+      }
+    },
     "node_modules/tryer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -22010,9 +22018,11 @@
       "version": "0.8.1",
       "dependencies": {
         "@yext/pages": "^1.0.0-beta.14",
+        "colors": "^1.4.0",
         "prettier": "^2.8.1",
         "react-dev-utils": "^12.0.1",
         "simple-git": "^3.16.0",
+        "true-myth": "^6.2.0",
         "ts-morph": "^18.0.0",
         "typescript": "^5.0.4",
         "uuid": "^9.0.0"
@@ -22024,6 +22034,7 @@
         "@types/uuid": "^9.0.0",
         "@yext/search-ui-react": "1.1.0",
         "jest": "^29.5.0",
+        "jest-matcher-utils": "^29.5.0",
         "react": "^18.2.0",
         "vite": "^4.3.1",
         "webpack": "^5.75.0"
@@ -22776,6 +22787,14 @@
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-12.0.0.tgz",
       "integrity": "sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w=="
+    },
+    "packages/studio-plugin/node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "packages/studio-plugin/node_modules/convert-source-map": {
       "version": "2.0.0",

--- a/packages/studio-plugin/jest.config.ts
+++ b/packages/studio-plugin/jest.config.ts
@@ -6,5 +6,7 @@ const config: Config = {
   collectCoverageFrom: ["src/**", "!src/types/**", "!src/index.ts"],
   resetMocks: true,
   restoreMocks: true,
+  transformIgnorePatterns: ["node_modules/(?!true-myth)"],
+  setupFilesAfterEnv: ["<rootDir>/tests/__setup__/setup-env.ts"],
 };
 export default config;

--- a/packages/studio-plugin/package.json
+++ b/packages/studio-plugin/package.json
@@ -25,9 +25,11 @@
   },
   "dependencies": {
     "@yext/pages": "^1.0.0-beta.14",
+    "colors": "^1.4.0",
     "prettier": "^2.8.1",
     "react-dev-utils": "^12.0.1",
     "simple-git": "^3.16.0",
+    "true-myth": "^6.2.0",
     "ts-morph": "^18.0.0",
     "typescript": "^5.0.4",
     "uuid": "^9.0.0"
@@ -42,6 +44,7 @@
     "@types/uuid": "^9.0.0",
     "@yext/search-ui-react": "1.1.0",
     "jest": "^29.5.0",
+    "jest-matcher-utils": "^29.5.0",
     "react": "^18.2.0",
     "vite": "^4.3.1",
     "webpack": "^5.75.0"

--- a/packages/studio-plugin/src/ParsingOrchestrator.ts
+++ b/packages/studio-plugin/src/ParsingOrchestrator.ts
@@ -16,6 +16,7 @@ import { Project } from "ts-morph";
 import typescript from "typescript";
 import { NpmLookup } from "./utils";
 import { RequiredStudioConfig } from "./parsers/getStudioConfig";
+import prettyPrintError from "./errors/prettyPrintError";
 
 export function createTsMorphProject() {
   return new Project({
@@ -152,7 +153,18 @@ export default class ParsingOrchestrator {
     const siteSettings = this.getSiteSettings();
     const pageNameToPageState = Object.keys(this.pageNameToPageFile).reduce(
       (prev, curr) => {
-        prev[curr] = this.pageNameToPageFile[curr].getPageState();
+        const pageStateResult = this.pageNameToPageFile[curr].getPageState();
+
+        // TODO(SLAP-2686): Confirm behavior for failure case with Product.
+        if (pageStateResult.isOk) {
+          prev[curr] = pageStateResult.value;
+        } else {
+          prettyPrintError(
+            `Failed to get PageState for "${curr}"`,
+            pageStateResult.error.message
+          );
+        }
+
         return prev;
       },
       {}

--- a/packages/studio-plugin/src/errors/ParsingError.ts
+++ b/packages/studio-plugin/src/errors/ParsingError.ts
@@ -1,0 +1,13 @@
+export enum ParsingErrorKind {
+  FailedToParsePageState = "FailedToParsePageState",
+}
+
+/**
+ * An interface representing errors that occur during the parsing of Components,
+ * their Prop interfaces, or Component Trees.
+ */
+export interface ParsingError {
+  kind: `${ParsingErrorKind}`;
+  message: string;
+  stack?: string;
+}

--- a/packages/studio-plugin/src/errors/prettyPrintError.ts
+++ b/packages/studio-plugin/src/errors/prettyPrintError.ts
@@ -1,0 +1,8 @@
+import colors from "colors";
+
+export default function prettyPrintError(header: string, reason: string) {
+  console.error(colors.bgRed(header));
+  console.group();
+  console.error(colors.red(reason));
+  console.groupEnd();
+}

--- a/packages/studio-plugin/src/parsers/helpers/StaticParsingHelpers.ts
+++ b/packages/studio-plugin/src/parsers/helpers/StaticParsingHelpers.ts
@@ -140,7 +140,9 @@ export default class StaticParsingHelpers {
     if (c.isKind(SyntaxKind.JsxText)) {
       if (c.getLiteralText().trim().length) {
         throw new Error(
-          `Found JsxText with content "${c.getLiteralText()}". JsxText is not currently supported.`
+          `Found JsxText with content "${c
+            .getLiteralText()
+            .trim()}". JsxText is not currently supported.`
         );
       }
       return [];

--- a/packages/studio-plugin/tests/ParsingOrchestrator.test.ts
+++ b/packages/studio-plugin/tests/ParsingOrchestrator.test.ts
@@ -15,6 +15,9 @@ import { Project } from "ts-morph";
 import sampleComponentPluginConfig from "./__fixtures__/PluginConfig/SampleComponent";
 import fs from "fs";
 import getLocalDataMapping from "../src/parsers/getLocalDataMapping";
+import prettyPrintError from "../src/errors/prettyPrintError";
+
+jest.mock("../src/errors/prettyPrintError");
 
 const mockGetPathToModuleResponse = path.join(
   process.cwd(),
@@ -186,9 +189,11 @@ it("throws an error when the page imports components from unexpected folders", (
     __dirname,
     "./__fixtures__/ParsingOrchestrator/src/pages"
   );
-  const orchestrator = createParsingOrchestrator({ paths: userPaths });
-  expect(() => orchestrator.getStudioData()).toThrow(
-    /^Could not get FileMetadata for/
+  createParsingOrchestrator({ paths: userPaths }).getStudioData();
+  expect(prettyPrintError).toHaveBeenCalledTimes(2);
+  expect(prettyPrintError).toHaveBeenCalledWith(
+    expect.stringMatching(/^Failed to get PageState/),
+    expect.stringMatching(/^Could not get FileMetadata for/)
   );
 });
 

--- a/packages/studio-plugin/tests/__setup__/setup-env.d.ts
+++ b/packages/studio-plugin/tests/__setup__/setup-env.d.ts
@@ -1,0 +1,9 @@
+export {};
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toHaveErrorMessage(expected: string | RegExp): R;
+    }
+  }
+}

--- a/packages/studio-plugin/tests/__setup__/setup-env.ts
+++ b/packages/studio-plugin/tests/__setup__/setup-env.ts
@@ -1,0 +1,39 @@
+import { Result } from "true-myth";
+import { printReceived, printExpected } from "jest-matcher-utils";
+
+function toHaveErrorMessage(
+  actual: Result<unknown, { message: string }>,
+  expected: string | RegExp
+) {
+  if (!actual.isErr) {
+    return {
+      pass: false,
+      message: () =>
+        `Received ${printReceived(
+          actual.value
+        )} instead of the error ${printExpected(expected)}`,
+    };
+  }
+
+  const actualErrorMessage = actual.error.message;
+  const pass = !!actualErrorMessage.match(expected);
+
+  if (!pass) {
+    return {
+      pass,
+      message: () =>
+        `Expected Error of ${printExpected(
+          expected
+        )}, received ${actualErrorMessage}}`,
+    };
+  }
+
+  return {
+    pass: true,
+    message: () => "",
+  };
+}
+
+expect.extend({
+  toHaveErrorMessage,
+});

--- a/packages/studio-plugin/tests/__utils__/asserts.ts
+++ b/packages/studio-plugin/tests/__utils__/asserts.ts
@@ -1,0 +1,8 @@
+import { Result } from "true-myth";
+import { Ok } from "true-myth/dist/public/result";
+
+export function assertIsOk<T, E>(
+  result: Result<T, E>
+): asserts result is Ok<T, E> {
+  expect(result.isOk).toBeTruthy();
+}

--- a/packages/studio-plugin/tests/sourcefiles/PageFile.getPageState.test.ts
+++ b/packages/studio-plugin/tests/sourcefiles/PageFile.getPageState.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../__fixtures__/componentStates";
 import { createTsMorphProject } from "../../src/ParsingOrchestrator";
 import { mockUUID } from "../__utils__/spies";
+import { assertIsOk } from "../__utils__/asserts";
 
 jest.mock("uuid");
 
@@ -52,21 +53,33 @@ describe("getPageState", () => {
     const pageFile = createPageFile("reactFragmentPage");
     const result = pageFile.getPageState();
 
-    expect(result.componentTree).toEqual([fragmentComponent, ...componentTree]);
+    assertIsOk(result);
+    expect(result.value.componentTree).toEqual([
+      fragmentComponent,
+      ...componentTree,
+    ]);
   });
 
   it("correctly parses page with top-level Fragment", () => {
     const pageFile = createPageFile("fragmentPage");
     const result = pageFile.getPageState();
 
-    expect(result.componentTree).toEqual([fragmentComponent, ...componentTree]);
+    assertIsOk(result);
+    expect(result.value.componentTree).toEqual([
+      fragmentComponent,
+      ...componentTree,
+    ]);
   });
 
   it("correctly parses page with top-level Fragment in short syntax", () => {
     const pageFile = createPageFile("shortFragmentSyntaxPage");
     const result = pageFile.getPageState();
 
-    expect(result.componentTree).toEqual([fragmentComponent, ...componentTree]);
+    assertIsOk(result);
+    expect(result.value.componentTree).toEqual([
+      fragmentComponent,
+      ...componentTree,
+    ]);
   });
 
   it("correctly parses page with top-level div component and logs warning", () => {
@@ -76,7 +89,8 @@ describe("getPageState", () => {
     const pageFile = createPageFile("divPage");
     const result = pageFile.getPageState();
 
-    expect(result.componentTree).toEqual([
+    assertIsOk(result);
+    expect(result.value.componentTree).toEqual([
       {
         kind: ComponentStateKind.BuiltIn,
         componentName: "div",
@@ -95,7 +109,8 @@ describe("getPageState", () => {
     const pageFile = createPageFile("repeaterPage");
     const result = pageFile.getPageState();
 
-    expect(result.componentTree).toContainEqual({
+    assertIsOk(result);
+    expect(result.value.componentTree).toContainEqual({
       kind: ComponentStateKind.Repeater,
       uuid: "mock-uuid-1",
       parentUUID: "mock-uuid-0",
@@ -112,14 +127,16 @@ describe("getPageState", () => {
     const pageFile = createPageFile("nestedBannerPage");
     const result = pageFile.getPageState();
 
-    expect(result.componentTree).toEqual(nestedBannerComponentTree);
+    assertIsOk(result);
+    expect(result.value.componentTree).toEqual(nestedBannerComponentTree);
   });
 
   it("correctly parses page with variable statement and no parentheses around return statement", () => {
     const pageFile = createPageFile("noReturnParenthesesPage");
     const result = pageFile.getPageState();
 
-    expect(result.componentTree).toEqual([
+    assertIsOk(result);
+    expect(result.value.componentTree).toEqual([
       fragmentComponent,
       {
         ...componentTree[1],
@@ -132,7 +149,8 @@ describe("getPageState", () => {
     const pageFile = createPageFile("shortFragmentSyntaxPage");
     const result = pageFile.getPageState();
 
-    expect(result.cssImports).toEqual([
+    assertIsOk(result);
+    expect(result.value.cssImports).toEqual([
       "./index.css",
       "@yext/search-ui-react/index.css",
     ]);
@@ -142,20 +160,24 @@ describe("getPageState", () => {
     const pageFile = createPageFile("shortFragmentSyntaxPage");
     const result = pageFile.getPageState();
 
-    expect(result.filepath).toEqual(getPagePath("shortFragmentSyntaxPage"));
+    assertIsOk(result);
+    expect(result.value.filepath).toEqual(
+      getPagePath("shortFragmentSyntaxPage")
+    );
   });
 
   it("returns empty component tree when parses a page without return statement", () => {
     const pageFile = createPageFile("noReturnStatementPage");
     const result = pageFile.getPageState();
-    expect(result.componentTree).toEqual([]);
+    assertIsOk(result);
+    expect(result.value.componentTree).toEqual([]);
   });
 
   describe("throws errors", () => {
     it("throws an error when the return statement has no top-level Jsx node", () => {
       const pageFile = createPageFile("noTopLevelJsxPage");
 
-      expect(() => pageFile.getPageState()).toThrowError(
+      expect(pageFile.getPageState()).toHaveErrorMessage(
         /^Unable to find top-level JSX element or JSX fragment type in the default export at path: /
       );
     });
@@ -163,23 +185,22 @@ describe("getPageState", () => {
     it("throws an error when a JsxSpreadAttribute is found on the page", () => {
       const pageFile = createPageFile("jsxSpreadAttributePage");
 
-      expect(() => pageFile.getPageState()).toThrowError(
+      expect(pageFile.getPageState()).toHaveErrorMessage(
         "Error parsing `{...props}`: JsxSpreadAttribute is not currently supported."
       );
     });
 
     it("throws an error when JsxText is found on the page", () => {
       const pageFile = createPageFile("jsxTextPage");
-
-      expect(() => pageFile.getPageState()).toThrowError(
-        'Found JsxText with content "\n      Text\n      ". JsxText is not currently supported.'
+      expect(pageFile.getPageState()).toHaveErrorMessage(
+        'Found JsxText with content "Text". JsxText is not currently supported.'
       );
     });
 
     it("throws an error when a non-map JsxExpression is found on the page", () => {
       const pageFile = createPageFile("jsxExpressionPage");
 
-      expect(() => pageFile.getPageState()).toThrowError(
+      expect(pageFile.getPageState()).toHaveErrorMessage(
         'Jsx nodes of kind "JsxExpression" are not supported for direct use' +
           " in page files except for `map` function expressions."
       );
@@ -188,7 +209,7 @@ describe("getPageState", () => {
     it("throws an error when a Repeater tries to repeat a built-in component", () => {
       const pageFile = createPageFile("builtInRepeaterPage");
 
-      expect(() => pageFile.getPageState()).toThrowError(
+      expect(pageFile.getPageState()).toHaveErrorMessage(
         "Error parsing map expression: repetition of built-in components is not supported."
       );
     });
@@ -196,7 +217,7 @@ describe("getPageState", () => {
     it("throws when an ObjectLiteralExpression is returned by the page", () => {
       const pageFile = createPageFile("returnsObject");
 
-      expect(() => pageFile.getPageState()).toThrowError(
+      expect(pageFile.getPageState()).toHaveErrorMessage(
         /^Unable to find top-level JSX element or JSX fragment/
       );
     });
@@ -204,7 +225,7 @@ describe("getPageState", () => {
     it("throws when an ArrayLiteralExpression is returned by the page", () => {
       const pageFile = createPageFile("returnsArray");
 
-      expect(() => pageFile.getPageState()).toThrowError(
+      expect(pageFile.getPageState()).toHaveErrorMessage(
         /^Unable to find top-level JSX element or JSX fragment/
       );
     });

--- a/packages/studio-plugin/tests/tsconfig.json
+++ b/packages/studio-plugin/tests/tsconfig.json
@@ -6,6 +6,10 @@
     "parsers",
     "writers",
     "sourcefiles",
-    "*.test.ts"
-  ]
+    "*.test.ts",
+    "**/*.d.ts"
+  ],
+  "compilerOptions": {
+    "types": ["jest", "./__setup__/setup-env.ts", "node"]
+  }
 }

--- a/packages/studio-plugin/tsconfig.jest.json
+++ b/packages/studio-plugin/tsconfig.jest.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "types": ["jest", "./tests/__setup__/setup-env.ts"]
   },
   "include": ["tests"],
   "exclude": ["tests/__fixtures__/**/*.tsx"]

--- a/packages/studio/jest.config.ts
+++ b/packages/studio/jest.config.ts
@@ -7,7 +7,7 @@ const config: Config = {
   resetMocks: true,
   restoreMocks: true,
   testEnvironment: "jsdom",
-  transformIgnorePatterns: ["node_modules/(?!react-tooltip/.*)"],
+  transformIgnorePatterns: ["node_modules/(?!react-tooltip|true-myth)"],
   setupFilesAfterEnv: ["<rootDir>/tests/__setup__/setup-env.ts"],
   transform: {
     "\\.[jt]sx?$": "babel-jest",


### PR DESCRIPTION
This PR introduces the `ParsingError` interface for the true-myth library, adds a custom jest matcher,
and pretty printer for our errors.

J=SLAP-2684
TEST=auto