### PR TITLE
Require getPath for PagesJS pages

### DIFF
--- a/apps/test-site/src/pages/UniversalPage.tsx
+++ b/apps/test-site/src/pages/UniversalPage.tsx
@@ -1,4 +1,4 @@
-import { TemplateConfig, TemplateProps } from "@yext/pages";
+import { GetPath, TemplateConfig, TemplateProps } from "@yext/pages";
 import { AceComponent } from "@yext/sample-component";
 import Banner from "../components/Banner";
 import Button from "../components/Button";
@@ -11,8 +11,11 @@ export const config: TemplateConfig = {
     $id: "studio-stream-id",
     filter: {},
     localization: { locales: ["en"], primary: false },
-    fields: ["services", "address.city"],
+    fields: ["services", "address"],
   },
+};
+export const getPath: GetPath<TemplateProps> = ({ document }) => {
+  return document.slug;
 };
 
 export default function UniversalPage({ document }: TemplateProps) {

--- a/packages/studio-plugin/src/parsers/GetPathParser.ts
+++ b/packages/studio-plugin/src/parsers/GetPathParser.ts
@@ -27,12 +27,15 @@ export default class GetPathParser {
 
   /**
    * If a getPath function is defined and a single, top-level, string literal
-   * is returned from it, returns that string literal.
+   * is returned from it, returns that string literal. If a getPath function is
+   * not defined, an error is thrown.
    */
   getReturnStringLiteral(): StringLiteral | undefined {
     const getPathFunction = this.findGetPathFunction();
     if (!getPathFunction) {
-      return;
+      throw new Error(
+        "Error parsing getPath value: no getPath function found."
+      );
     }
     if (getPathFunction.isKind(SyntaxKind.FunctionDeclaration)) {
       const block = getPathFunction.getFirstChildByKind(SyntaxKind.Block);

--- a/packages/studio-plugin/tests/ParsingOrchestrator.test.ts
+++ b/packages/studio-plugin/tests/ParsingOrchestrator.test.ts
@@ -133,7 +133,7 @@ describe("aggregates data as expected", () => {
     });
   });
 
-  describe("localDataMapping", () => {
+  describe("PagesJS state", () => {
     it("aggregates pageNameToPageState as expected when receives a localDataMapping", async () => {
       const localDataMapping = await getLocalDataMapping(userPaths.localData);
       const orchestrator = createParsingOrchestrator({
@@ -144,9 +144,15 @@ describe("aggregates data as expected", () => {
       expect(studioData.pageNameToPageState).toEqual({
         basicPage: {
           ...basicPageState,
-          pagesJS: { entityFiles: ["basicpage-stream.json"] },
+          pagesJS: {
+            entityFiles: ["basicpage-stream.json"],
+            getPathValue: "index.html",
+          },
         },
-        pageWithModules: pageWithModulesState,
+        pageWithModules: {
+          ...pageWithModulesState,
+          pagesJS: { getPathValue: "modules.html" },
+        },
       });
     });
   });

--- a/packages/studio-plugin/tests/__fixtures__/ParsingOrchestrator/src/pages/basicPage.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/ParsingOrchestrator/src/pages/basicPage.tsx
@@ -1,5 +1,7 @@
 import Card from "../components/Card";
 
+export const getPath = () => "index.html";
+
 export default function IndexPage() {
   return (
     <div>

--- a/packages/studio-plugin/tests/__fixtures__/ParsingOrchestrator/src/pages/pageWithModules.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/ParsingOrchestrator/src/pages/pageWithModules.tsx
@@ -1,6 +1,8 @@
 import NestedBanner from "../components/NestedBanner";
 import NestedModule from "../modules/a/b/NestedModule";
 
+export const getPath = () => "modules.html";
+
 export default function IndexPage() {
   return (
     <NestedBanner>

--- a/packages/studio-plugin/tests/parsers/GetPathParser.test.ts
+++ b/packages/studio-plugin/tests/parsers/GetPathParser.test.ts
@@ -46,16 +46,6 @@ describe("parseGetPathValue", () => {
       expect(parser.parseGetPathValue()).toBeUndefined();
     });
 
-    it("returns undefined if no getPath function is found", () => {
-      const parser = createParser('const path = () => "index.html";');
-      expect(parser.parseGetPathValue()).toBeUndefined();
-    });
-
-    it("returns undefined if getPath variable is not a function", () => {
-      const parser = createParser('const getPath = "index.html";');
-      expect(parser.parseGetPathValue()).toBeUndefined();
-    });
-
     it("returns undefined if there is no single, top-level return statement", () => {
       const parser = createParser(
         `const getPath = ({ document }) => {
@@ -67,6 +57,22 @@ describe("parseGetPathValue", () => {
         };`
       );
       expect(parser.parseGetPathValue()).toBeUndefined();
+    });
+  });
+
+  describe("error cases", () => {
+    it("throws an error if no getPath variable is found", () => {
+      const parser = createParser('const path = () => "index.html";');
+      expect(() => parser.parseGetPathValue()).toThrowError(
+        "Error parsing getPath value: no getPath function found."
+      );
+    });
+
+    it("throws an error if getPath variable is not a function", () => {
+      const parser = createParser('const getPath = "index.html";');
+      expect(() => parser.parseGetPathValue()).toThrowError(
+        "Error parsing getPath value: no getPath function found."
+      );
     });
   });
 });


### PR DESCRIPTION
Now that adding new pages to a PagesJS repo through the Studio UI adds a `getPath` function, update the parsing logic to throw an error if a `getPath` function is not found in a page file.

J=SLAP-2711
TEST=auto, manual

- Tried starting the test-site without a `getPath` function in `UniversalPage` and saw it give an error. After adding the `getPath` function, `UniversalPage` is available in the UI.
- Tried starting the test-site with `isPagesJSRepo: false` in the Studio config. Saw there was no error and `UniversalPage` (without a `getPath` function) was editable in the UI