### PR TITLE
Parse and write expressions in getPath function

### DIFF
--- a/apps/test-site/src/pages/UniversalPage.tsx
+++ b/apps/test-site/src/pages/UniversalPage.tsx
@@ -14,7 +14,9 @@ export const config: TemplateConfig = {
     fields: ["services", "address"],
   },
 };
-export const getPath: GetPath<TemplateProps> = ({ document }) => {
+export const getPath: GetPath<TemplateProps> = ({
+  document,
+}: TemplateProps) => {
   return document.slug;
 };
 

--- a/packages/studio-plugin/src/parsers/helpers/StaticParsingHelpers.ts
+++ b/packages/studio-plugin/src/parsers/helpers/StaticParsingHelpers.ts
@@ -40,7 +40,7 @@ export type ParsedImport = {
  * files within Studio.
  */
 export default class StaticParsingHelpers {
-  private static parseInitializer(initializer: Expression): TypelessPropVal {
+  static parseInitializer(initializer: Expression): TypelessPropVal {
     if (initializer.isKind(SyntaxKind.StringLiteral)) {
       return {
         value: initializer.compilerNode.text,

--- a/packages/studio-plugin/src/parsers/helpers/TsMorphHelpers.ts
+++ b/packages/studio-plugin/src/parsers/helpers/TsMorphHelpers.ts
@@ -46,6 +46,19 @@ export default class TsMorphHelpers {
   }
 
   /**
+   * Similar to ts-morph's getFirstChildByKind but accepts multiple kinds.
+   */
+  static getFirstChildOfKind<T extends ReadonlyArray<SyntaxKind>>(
+    node: Node,
+    ...kinds: T
+  ): KindToNodeMappings[OneOf<T>] | undefined {
+    return this.getChildOfKind(
+      (condition) => node.getFirstChild(condition),
+      ...kinds
+    );
+  }
+
+  /**
    * Similar to ts-morph's getLastChildByKindOrThrow but accepts multiple kinds.
    */
   static getLastChildOfKindOrThrow<T extends ReadonlyArray<SyntaxKind>>(
@@ -58,9 +71,19 @@ export default class TsMorphHelpers {
       ...kinds
     );
   }
+
+  /**
+   * Similar to ts-morph's isKind but accepts multiple kinds.
+   */
+  static isKind<T extends ReadonlyArray<SyntaxKind>>(
+    node: Node,
+    ...kinds: T
+  ): node is KindToNodeMappings[OneOf<T>] {
+    return kinds.some((k) => node.isKind(k));
+  }
 }
 
-type OneOf<T extends ReadonlyArray<unknown>> = T extends ReadonlyArray<
+export type OneOf<T extends ReadonlyArray<unknown>> = T extends ReadonlyArray<
   infer OneOf
 >
   ? OneOf

--- a/packages/studio-plugin/src/types/PageState.ts
+++ b/packages/studio-plugin/src/types/PageState.ts
@@ -1,4 +1,5 @@
 import { ComponentState } from "./ComponentState";
+import { PropValueKind } from "./PropValues";
 
 export type PageState = {
   componentTree: ComponentState[];
@@ -16,9 +17,14 @@ export type PagesJsState = {
   entityFiles?: string[];
   /**
    * Return value of the getPath function if it returns a single, top-level,
-   * string literal value.
+   * string literal or expression.
    */
-  getPathValue: string | undefined;
+  getPathValue: GetPathVal | undefined;
+};
+
+export type GetPathVal = {
+  kind: PropValueKind;
+  value: string;
 };
 
 export type ErrorPageState = {

--- a/packages/studio-plugin/src/utils/ComponentTreeHelpers.ts
+++ b/packages/studio-plugin/src/utils/ComponentTreeHelpers.ts
@@ -6,6 +6,7 @@ import {
   TypelessPropVal,
 } from "../types";
 import ComponentStateHelpers from "./ComponentStateHelpers";
+import ExpressionHelpers from "./ExpressionHelpers";
 import TypeGuards from "./TypeGuards";
 
 /**
@@ -105,18 +106,9 @@ export default class ComponentTreeHelpers {
         : expressionPropValues;
     });
 
-    // This is used to create the regex: /\${source\..*}/
-    const regexStr = "\\${" + source + "\\..*}";
-    const templateStringRegex = new RegExp(regexStr);
-
-    return expressions.some((e) => {
-      return (
-        e === source ||
-        e.startsWith(source + ".") ||
-        e.match(templateStringRegex) ||
-        e.includes("${" + source + "}")
-      );
-    });
+    return expressions.some((e) =>
+      ExpressionHelpers.usesExpressionSource(e, source)
+    );
   }
 
   private static getExpressionUsagesFromProps(

--- a/packages/studio-plugin/src/utils/ExpressionHelpers.ts
+++ b/packages/studio-plugin/src/utils/ExpressionHelpers.ts
@@ -1,0 +1,21 @@
+/**
+ * A static class for housing various util functions related to expressions.
+ */
+export default class ExpressionHelpers {
+  /**
+   * Checks whether the expression uses a specific expression source, such as
+   * `document` or `props`.
+   */
+  static usesExpressionSource(expression: string, source: string) {
+    // This is used to create the regex: /\${source\..*}/
+    const regexStr = "\\${" + source + "\\..*}";
+    const templateStringRegex = new RegExp(regexStr);
+
+    return (
+      expression === source ||
+      expression.startsWith(source + ".") ||
+      expression.match(templateStringRegex) ||
+      expression.includes("${" + source + "}")
+    );
+  }
+}

--- a/packages/studio-plugin/src/writers/PagesJsWriter.ts
+++ b/packages/studio-plugin/src/writers/PagesJsWriter.ts
@@ -1,0 +1,28 @@
+import { PAGESJS_TEMPLATE_PROPS_TYPE, PAGES_PACKAGE_NAME } from "../constants";
+import StudioSourceFileWriter from "./StudioSourceFileWriter";
+import { ArrowFunction, FunctionDeclaration } from "ts-morph";
+
+/**
+ * PagesJsWriter is a class for housing the PagesJS-specific updating logic for
+ * a PageFile.
+ */
+export default class PagesJsWriter {
+  constructor(private studioSourceFileWriter: StudioSourceFileWriter) {}
+
+  /** Adds named imports from the PagesJS package. */
+  addPagesJsImports(namedImports: string[]): void {
+    this.studioSourceFileWriter.addFileImport({
+      source: PAGES_PACKAGE_NAME,
+      namedImports,
+    });
+  }
+
+  /** Adds a destructured template props paramater to the function. */
+  addTemplateParameter(componentFunction: FunctionDeclaration | ArrowFunction) {
+    this.studioSourceFileWriter.updateFunctionParameter(
+      componentFunction,
+      PAGESJS_TEMPLATE_PROPS_TYPE,
+      ["document"]
+    );
+  }
+}

--- a/packages/studio-plugin/src/writers/StreamConfigWriter.ts
+++ b/packages/studio-plugin/src/writers/StreamConfigWriter.ts
@@ -2,7 +2,6 @@ import { TemplateConfig } from "@yext/pages";
 import { ArrowFunction, FunctionDeclaration } from "ts-morph";
 import {
   PAGESJS_TEMPLATE_PROPS_TYPE,
-  PAGES_PACKAGE_NAME,
   TEMPLATE_STRING_EXPRESSION_REGEX,
 } from "../constants";
 import TypeGuards from "../utils/TypeGuards";
@@ -16,6 +15,7 @@ import { ComponentState, ComponentStateKind } from "../types/ComponentState";
 import StudioSourceFileWriter from "./StudioSourceFileWriter";
 import { StreamsDataExpression } from "../types/Expression";
 import pagesJSFieldsMerger from "../utils/StreamConfigFieldsMerger";
+import PagesJsWriter from "./PagesJsWriter";
 
 const STREAM_CONFIG_VARIABLE_NAME = "config";
 const STREAM_CONFIG_VARIABLE_TYPE = "TemplateConfig";
@@ -25,10 +25,14 @@ const STREAM_CONFIG_VARIABLE_TYPE = "TemplateConfig";
  * updating logic for Stream config in PageFile.
  */
 export default class StreamConfigWriter {
+  private pagesJsWriter: PagesJsWriter;
+
   constructor(
     private studioSourceFileWriter: StudioSourceFileWriter,
     private studioSourceFileParser: StudioSourceFileParser
-  ) {}
+  ) {
+    this.pagesJsWriter = new PagesJsWriter(studioSourceFileWriter);
+  }
 
   /**
    * Extracts stream's data expressions used in the provided component tree,
@@ -163,17 +167,13 @@ export default class StreamConfigWriter {
   }
 
   addStreamImport(): void {
-    this.studioSourceFileWriter.addFileImport({
-      source: PAGES_PACKAGE_NAME,
-      namedImports: [STREAM_CONFIG_VARIABLE_TYPE, PAGESJS_TEMPLATE_PROPS_TYPE],
-    });
+    this.pagesJsWriter.addPagesJsImports([
+      STREAM_CONFIG_VARIABLE_TYPE,
+      PAGESJS_TEMPLATE_PROPS_TYPE,
+    ]);
   }
 
   addStreamParameter(componentFunction: FunctionDeclaration | ArrowFunction) {
-    this.studioSourceFileWriter.updateFunctionParameter(
-      componentFunction,
-      PAGESJS_TEMPLATE_PROPS_TYPE,
-      ["document"]
-    );
+    this.pagesJsWriter.addTemplateParameter(componentFunction);
   }
 }

--- a/packages/studio-plugin/tests/ParsingOrchestrator.test.ts
+++ b/packages/studio-plugin/tests/ParsingOrchestrator.test.ts
@@ -8,6 +8,7 @@ import {
   FileMetadataKind,
   PageState,
   PluginConfig,
+  PropValueKind,
   StudioData,
   UserPaths,
 } from "../src/types";
@@ -146,12 +147,17 @@ describe("aggregates data as expected", () => {
           ...basicPageState,
           pagesJS: {
             entityFiles: ["basicpage-stream.json"],
-            getPathValue: "index.html",
+            getPathValue: { kind: PropValueKind.Literal, value: "index.html" },
           },
         },
         pageWithModules: {
           ...pageWithModulesState,
-          pagesJS: { getPathValue: "modules.html" },
+          pagesJS: {
+            getPathValue: {
+              kind: PropValueKind.Expression,
+              value: "`modules.html`",
+            },
+          },
         },
       });
     });

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithPropertyGetPath.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithPropertyGetPath.tsx
@@ -1,0 +1,9 @@
+import { GetPath, TemplateProps } from "@yext/pages";
+
+export const getPath: GetPath<TemplateProps> = ({
+  document,
+}: TemplateProps) => {
+  return document.slug;
+};
+
+export default function IndexPage() {}

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithTemplateGetPath.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithTemplateGetPath.tsx
@@ -1,0 +1,9 @@
+import { GetPath, TemplateProps } from "@yext/pages";
+
+export const getPath: GetPath<TemplateProps> = ({
+  document,
+}: TemplateProps) => {
+  return `test-${document.slug}`;
+};
+
+export default function IndexPage() {}

--- a/packages/studio-plugin/tests/__fixtures__/ParsingOrchestrator/src/pages/pageWithModules.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/ParsingOrchestrator/src/pages/pageWithModules.tsx
@@ -1,7 +1,7 @@
 import NestedBanner from "../components/NestedBanner";
 import NestedModule from "../modules/a/b/NestedModule";
 
-export const getPath = () => "modules.html";
+export const getPath = () => `modules.html`;
 
 export default function IndexPage() {
   return (

--- a/packages/studio-plugin/tests/sourcefiles/PageFile.getPageState.test.ts
+++ b/packages/studio-plugin/tests/sourcefiles/PageFile.getPageState.test.ts
@@ -1,6 +1,6 @@
 import PageFile from "../../src/sourcefiles/PageFile";
 import { ComponentStateKind } from "../../src/types/ComponentState";
-import { PropValueType } from "../../src/types/PropValues";
+import { PropValueKind, PropValueType } from "../../src/types/PropValues";
 import { getPagePath } from "../__utils__/getFixturePath";
 import { FileMetadata, FileMetadataKind, PropShape } from "../../src/types";
 import {
@@ -172,7 +172,10 @@ describe("getPageState", () => {
     const result = pageFile.getPageState();
 
     assertIsOk(result);
-    expect(result.value.pagesJS?.getPathValue).toEqual("index.html");
+    expect(result.value.pagesJS?.getPathValue).toEqual({
+      kind: PropValueKind.Literal,
+      value: "index.html",
+    });
   });
 
   it("returns empty component tree when parses a page without return statement", () => {

--- a/packages/studio-plugin/tests/sourcefiles/PageFile.updatePageFile.test.ts
+++ b/packages/studio-plugin/tests/sourcefiles/PageFile.updatePageFile.test.ts
@@ -327,7 +327,7 @@ describe("updatePageFile", () => {
       pageFile.updatePageFile({
         ...basicPageState,
         pagesJS: {
-          getPathValue: "index.html",
+          getPathValue: { kind: PropValueKind.Literal, value: "index.html" },
         },
       });
       expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -336,21 +336,63 @@ describe("updatePageFile", () => {
       );
     });
 
-    it("updates existing getPath function's return value", () => {
-      const pageFile = createPageFile("PageWithGetPath", tsMorphProject);
-      pageFile.updatePageFile({
-        ...basicPageState,
-        pagesJS: {
-          getPathValue: "static.html",
-        },
+    describe("updates existing getPath function", () => {
+      it("updates to modified string literal value", () => {
+        const pageFile = createPageFile("PageWithGetPath", tsMorphProject);
+        pageFile.updatePageFile({
+          ...basicPageState,
+          pagesJS: {
+            getPathValue: { kind: PropValueKind.Literal, value: "static.html" },
+          },
+        });
+        expect(fs.writeFileSync).toHaveBeenCalledWith(
+          expect.stringContaining("PageWithGetPath.tsx"),
+          fs.readFileSync(
+            getPagePath("updatePageFile/PageWithModifiedGetPath"),
+            "utf-8"
+          )
+        );
       });
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringContaining("PageWithGetPath.tsx"),
-        fs.readFileSync(
-          getPagePath("updatePageFile/PageWithModifiedGetPath"),
-          "utf-8"
-        )
-      );
+
+      it("updates to template expression", () => {
+        const pageFile = createPageFile("PageWithGetPath", tsMorphProject);
+        pageFile.updatePageFile({
+          ...basicPageState,
+          pagesJS: {
+            getPathValue: {
+              kind: PropValueKind.Expression,
+              value: "`test-${document.slug}`",
+            },
+          },
+        });
+        expect(fs.writeFileSync).toHaveBeenCalledWith(
+          expect.stringContaining("PageWithGetPath.tsx"),
+          fs.readFileSync(
+            getPagePath("updatePageFile/PageWithTemplateGetPath"),
+            "utf-8"
+          )
+        );
+      });
+
+      it("updates to property access expression", () => {
+        const pageFile = createPageFile("PageWithGetPath", tsMorphProject);
+        pageFile.updatePageFile({
+          ...basicPageState,
+          pagesJS: {
+            getPathValue: {
+              kind: PropValueKind.Expression,
+              value: "document.slug",
+            },
+          },
+        });
+        expect(fs.writeFileSync).toHaveBeenCalledWith(
+          expect.stringContaining("PageWithGetPath.tsx"),
+          fs.readFileSync(
+            getPagePath("updatePageFile/PageWithPropertyGetPath"),
+            "utf-8"
+          )
+        );
+      });
     });
 
     it("does not modify getPath if getPathValue is undefined", () => {

--- a/packages/studio/src/components/PageSettingsButton.tsx
+++ b/packages/studio/src/components/PageSettingsButton.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from "react";
 import ButtonWithModal, { renderModalFunction } from "./common/ButtonWithModal";
 import FormModal from "./common/FormModal";
 import { Tooltip } from "react-tooltip";
+import { PropValueKind } from "@yext/studio-plugin";
 
 type PageSettings = {
   url: string;
@@ -31,7 +32,7 @@ export default function PageSettingsButton({
   ]);
 
   const initialFormValue: PageSettings = useMemo(
-    () => ({ url: currGetPathValue ?? "" }),
+    () => ({ url: currGetPathValue?.value ?? "" }),
     [currGetPathValue]
   );
 
@@ -59,7 +60,9 @@ export default function PageSettingsButton({
     [handleModalSave, initialFormValue]
   );
 
-  const disabled = !currGetPathValue;
+  // TODO (SLAP-2714): Add support for editing expressions
+  const disabled =
+    !currGetPathValue || currGetPathValue.kind === PropValueKind.Expression;
   const tooltipAnchorID = `PageSettingsButton-${pageName}`;
 
   return (

--- a/packages/studio/src/store/StudioActions.ts
+++ b/packages/studio/src/store/StudioActions.ts
@@ -5,6 +5,7 @@ import {
   MessageID,
   ModuleMetadata,
   ModuleState,
+  PropValueKind,
   PropValues,
   RepeaterState,
   TypeGuards,
@@ -277,7 +278,12 @@ export default class StudioActions {
       componentTree: [],
       cssImports: [],
       filepath,
-      ...(isPagesJSRepo && { pagesJS: { getPathValue } }),
+      ...(isPagesJSRepo &&
+        getPathValue && {
+          pagesJS: {
+            getPathValue: { kind: PropValueKind.Literal, value: getPathValue },
+          },
+        }),
     });
     await this.updateActivePage(pageName);
   };

--- a/packages/studio/src/store/slices/pages/createPageSlice.ts
+++ b/packages/studio/src/store/slices/pages/createPageSlice.ts
@@ -1,4 +1,4 @@
-import { ComponentState, PageState } from "@yext/studio-plugin";
+import { ComponentState, PageState, PropValueKind } from "@yext/studio-plugin";
 import { isEqual } from "lodash";
 import path from "path-browserify";
 import initialStudioData from "virtual:yext-studio";
@@ -65,7 +65,7 @@ export const createPageSlice: SliceCreator<PageSlice> = (set, get) => {
         }
       });
     },
-    updateGetPathValue: (pageName: string, getPathValue: string) => {
+    updateGetPathValue: (pageName: string, value: string) => {
       set((store) => {
         const originalPagesJsState = store.pages[pageName].pagesJS;
         const originalGetPathValue = originalPagesJsState?.getPathValue;
@@ -75,10 +75,11 @@ export const createPageSlice: SliceCreator<PageSlice> = (set, get) => {
           );
         }
 
-        if (originalGetPathValue !== getPathValue) {
+        if (originalGetPathValue.value !== value) {
           store.pages[pageName].pagesJS = {
             ...originalPagesJsState,
-            getPathValue,
+            // TODO (SLAP-2714): Allow expression values
+            getPathValue: { kind: PropValueKind.Literal, value },
           };
           store.pendingChanges.pagesToUpdate.add(pageName);
         }

--- a/packages/studio/tests/components/ActivePagePanel.test.tsx
+++ b/packages/studio/tests/components/ActivePagePanel.test.tsx
@@ -3,7 +3,7 @@ import ActivePagePanel from "../../src/components/ActivePagePanel";
 import { mockPageSliceStates } from "../__utils__/mockPageSliceState";
 import useStudioStore from "../../src/store/useStudioStore";
 import mockStore from "../__utils__/mockStore";
-import { PageState } from "@yext/studio-plugin";
+import { PageState, PropValueKind } from "@yext/studio-plugin";
 
 const basePageState: PageState = {
   componentTree: [],
@@ -42,7 +42,7 @@ it("renders page settings button in PagesJS repo", () => {
         Universal: {
           ...basePageState,
           pagesJS: {
-            getPathValue: "index",
+            getPathValue: { kind: PropValueKind.Literal, value: "index" },
           },
         },
       },

--- a/packages/studio/tests/components/AddPageButton.test.tsx
+++ b/packages/studio/tests/components/AddPageButton.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import AddPageButton from "../../src/components/AddPageButton";
 import useStudioStore from "../../src/store/useStudioStore";
 import mockStore from "../__utils__/mockStore";
+import { PropValueKind } from "@yext/studio-plugin";
 
 beforeEach(() => {
   mockStore({
@@ -59,7 +60,9 @@ it("closes the modal when page name and url are added in PagesJS repo", async ()
     componentTree: [],
     cssImports: [],
     filepath: expect.stringContaining("test.tsx"),
-    pagesJS: { getPathValue: "testing" },
+    pagesJS: {
+      getPathValue: { kind: PropValueKind.Literal, value: "testing" },
+    },
   });
   expect(screen.queryByText("Save")).toBeNull();
 });

--- a/packages/studio/tests/components/PageSettingsButton.test.tsx
+++ b/packages/studio/tests/components/PageSettingsButton.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import useStudioStore from "../../src/store/useStudioStore";
 import mockStore from "../__utils__/mockStore";
 import PageSettingsButton from "../../src/components/PageSettingsButton";
-import { PageState } from "@yext/studio-plugin";
+import { PageState, PropValueKind } from "@yext/studio-plugin";
 
 const basePageState: PageState = {
   componentTree: [],
@@ -19,7 +19,7 @@ beforeEach(() => {
         universal: {
           ...basePageState,
           pagesJS: {
-            getPathValue: "index",
+            getPathValue: { kind: PropValueKind.Literal, value: "index" },
           },
         },
         location: basePageState,

--- a/packages/studio/tests/store/StudioActions/createPage.test.ts
+++ b/packages/studio/tests/store/StudioActions/createPage.test.ts
@@ -1,3 +1,4 @@
+import { PropValueKind } from "@yext/studio-plugin";
 import useStudioStore from "../../../src/store/useStudioStore";
 import mockStore from "../../__utils__/mockStore";
 
@@ -75,7 +76,9 @@ describe("PagesJS repo", () => {
         componentTree: [],
         cssImports: [],
         filepath: expect.stringContaining("test"),
-        pagesJS: { getPathValue: "testing" },
+        pagesJS: {
+          getPathValue: { kind: PropValueKind.Literal, value: "testing" },
+        },
       },
     });
   });

--- a/packages/studio/tests/store/createPageSlice/pageActions.test.ts
+++ b/packages/studio/tests/store/createPageSlice/pageActions.test.ts
@@ -3,13 +3,16 @@ import path from "path";
 import { mockPageSliceStates } from "../../__utils__/mockPageSliceState";
 import { PagesRecord } from "../../../src/store/models/slices/PageSlice";
 import mockStore from "../../__utils__/mockStore";
+import { PropValueKind } from "@yext/studio-plugin";
 
 const pages: PagesRecord = {
   universal: {
     componentTree: [],
     cssImports: [],
     filepath: "mock-filepath",
-    pagesJS: { getPathValue: "index.html" },
+    pagesJS: {
+      getPathValue: { kind: PropValueKind.Literal, value: "index.html" },
+    },
   },
 };
 
@@ -79,7 +82,10 @@ describe("updateGetPathValue", () => {
   it("updates getPathValue and pendingChanges", () => {
     useStudioStore.getState().pages.updateGetPathValue("universal", "index");
     const pageState = useStudioStore.getState().pages.pages["universal"];
-    expect(pageState.pagesJS?.getPathValue).toEqual("index");
+    expect(pageState.pagesJS?.getPathValue).toEqual({
+      kind: PropValueKind.Literal,
+      value: "index",
+    });
     const pendingChanges = useStudioStore.getState().pages.pendingChanges;
     expect(pendingChanges).toEqual({
       pagesToUpdate: new Set(["universal"]),


### PR DESCRIPTION
Add support for parsing and writing `getPath` functions that return expressions. SLAP-2714 will update the editor in the UI so that `getPath` expressions can be edited.

J=SLAP-2713
TEST=auto, manual

See that the `getPath` function of `UniversalPage` is parsed and written to file as expected.