### PR TITLE
Fix bug in square bracket regex

### DIFF
--- a/packages/studio/src/utils/TemplateExpressionFormatter.ts
+++ b/packages/studio/src/utils/TemplateExpressionFormatter.ts
@@ -24,10 +24,11 @@ export default class TemplateExpressionFormatter {
   }
 
   /**
-   * Converts `[[field]]` usages into `${document.<field>}`.
+   * Converts `[[<field>]]` usages into `${document.<field>}` and
+   * `[[<field>[<num>]]]` to `${document.<field>[<num>]}`.
    */
   private static convertSquareBracketsToCurlyBraces(value: string) {
-    return value.replaceAll(/\[\[(.*?)\]\]/g, (_substring, match) => {
+    return value.replaceAll(/\[\[(.*?(\[\d+\])?)\]\]/g, (_substring, match) => {
       return "${document." + match + "}";
     });
   }

--- a/packages/studio/tests/utils/TemplateExpressionFormatter.test.ts
+++ b/packages/studio/tests/utils/TemplateExpressionFormatter.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import TemplateExpressionFormatter from "../../src/utils/TemplateExpressionFormatter";
 
-const rawTemplateString = "`hi ${document.address} ${document.cat} bye`";
-const displayValue = "hi [[address]] [[cat]] bye";
+const rawTemplateString = "`hi ${document.address} ${document.cats[0]} bye`";
+const displayValue = "hi [[address]] [[cats[0]]] bye";
 
 it("converts raw expression values into display values correctly", () => {
   const actualValue =


### PR DESCRIPTION
Fix a bug when converting a template expression with an element access in square brackets to curly brackets. Previously, `[[services[0]]]` would be converted to `${document.services[0}]` instead of `${document.services[0]}`.

J=SLAP-2730
TEST=auto, manual

Type `[[services[0]]]` in a prop input and see that `${document.services[0]}` is saved to file.