### PR TITLE
Add modal for stream scope

### DIFF
--- a/packages/studio-plugin/src/writers/TemplateConfigWriter.ts
+++ b/packages/studio-plugin/src/writers/TemplateConfigWriter.ts
@@ -19,6 +19,7 @@ import pagesJSFieldsMerger from "../utils/StreamConfigFieldsMerger";
 import PagesJsWriter from "./PagesJsWriter";
 import { GetPathVal, PagesJsState } from "../types";
 import TemplateConfigParser from "../parsers/TemplateConfigParser";
+import { ComponentTreeHelpers } from "../utils";
 
 const TEMPLATE_CONFIG_VARIABLE_TYPE = "TemplateConfig";
 
@@ -174,11 +175,23 @@ export default class TemplateConfigWriter {
       TEMPLATE_CONFIG_VARIABLE_TYPE
     );
 
-    this.pagesJsWriter.addTemplateParameter(componentFunction);
-    this.pagesJsWriter.addPagesJsImports([
-      TEMPLATE_CONFIG_VARIABLE_TYPE,
-      PAGESJS_TEMPLATE_PROPS_TYPE,
-    ]);
+    this.addParametersAndImports(componentTree, componentFunction);
+  }
+
+  private addParametersAndImports(
+    componentTree: ComponentState[],
+    componentFunction: FunctionDeclaration | ArrowFunction
+  ) {
+    this.pagesJsWriter.addPagesJsImports([TEMPLATE_CONFIG_VARIABLE_TYPE]);
+
+    const usesDocument = ComponentTreeHelpers.usesExpressionSource(
+      componentTree,
+      "document"
+    );
+    if (usesDocument) {
+      this.pagesJsWriter.addTemplateParameter(componentFunction);
+      this.pagesJsWriter.addPagesJsImports([PAGESJS_TEMPLATE_PROPS_TYPE]);
+    }
   }
 
   isEntityPageState(

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithNoStreamPathsInTree.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithNoStreamPathsInTree.tsx
@@ -1,0 +1,18 @@
+import { GetPath, TemplateConfig, TemplateProps } from "@yext/pages";
+import ComplexBanner from "../../ComponentFile/ComplexBanner";
+
+export const config: TemplateConfig = {
+  stream: {
+    $id: "studio-stream-id",
+    localization: { locales: ["en"], primary: false },
+    filter: {},
+    fields: ["slug"],
+  },
+};
+export const getPath: GetPath<TemplateProps> = ({ document }) => {
+  return document.slug;
+};
+
+export default function IndexPage() {
+  return <ComplexBanner title="title" />;
+}

--- a/packages/studio-plugin/tests/sourcefiles/PageFile.updatePageFile.test.ts
+++ b/packages/studio-plugin/tests/sourcefiles/PageFile.updatePageFile.test.ts
@@ -222,6 +222,43 @@ describe("updatePageFile", () => {
       );
     });
 
+    it("does not add template props param if no stream paths in tree", () => {
+      addFilesToProject(tsMorphProject, [getComponentPath("ComplexBanner")]);
+      const pageFile = createPageFile("EmptyPage", tsMorphProject);
+      pageFile.updatePageFile({
+        ...entityPageState,
+        componentTree: [
+          {
+            kind: ComponentStateKind.Standard,
+            componentName: "ComplexBanner",
+            uuid: "mock-uuid-0",
+            props: {
+              title: {
+                kind: PropValueKind.Literal,
+                value: "title",
+                valueType: PropValueType.string,
+              },
+            },
+            metadataUUID: "mock-metadata-uuid",
+          },
+        ],
+        pagesJS: {
+          ...entityPageState.pagesJS,
+          getPathValue: {
+            kind: PropValueKind.Expression,
+            value: "document.slug",
+          },
+        },
+      });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining("EmptyPage.tsx"),
+        fs.readFileSync(
+          getPagePath("updatePageFile/PageWithNoStreamPathsInTree"),
+          "utf-8"
+        )
+      );
+    });
+
     it("dedupes stream document paths", () => {
       addFilesToProject(tsMorphProject, [getComponentPath("ComplexBanner")]);
       const pageFile = createPageFile(

--- a/packages/studio/src/components/AddPageButton/AddPageButton.tsx
+++ b/packages/studio/src/components/AddPageButton/AddPageButton.tsx
@@ -22,21 +22,26 @@ function AddPageButtonInternal() {
     store.actions.createPage,
   ]);
   const [step, setStep] = useState(getInitialStep(isPagesJSRepo));
-  const { actions } = useContext(AddPageContext);
+  const { state, actions } = useContext(AddPageContext);
   const { resetState } = actions;
 
   const handleConfirm = useCallback(
     async (pageName = "", url?: string) => {
       switch (step) {
         case FlowStep.SelectPageType:
+          setStep(
+            state.isStatic ? FlowStep.GetBasicPageData : FlowStep.GetStreamScope
+          );
+          break;
+        case FlowStep.GetStreamScope:
           setStep(FlowStep.GetBasicPageData);
           break;
         case FlowStep.GetBasicPageData:
-          await createPage(pageName, url);
+          await createPage(pageName, url, state.streamScope);
           break;
       }
     },
-    [step, createPage]
+    [step, createPage, state]
   );
 
   const decorateHandleClose = useCallback(

--- a/packages/studio/src/components/AddPageButton/AddPageContext.ts
+++ b/packages/studio/src/components/AddPageButton/AddPageContext.ts
@@ -1,11 +1,14 @@
+import { StreamScope } from "@yext/studio-plugin";
 import { createContext } from "react";
 
 export interface AddPageData {
   isStatic: boolean;
+  streamScope?: StreamScope;
 }
 
 export interface AddPageActions {
   setIsStatic: (isStatic: boolean) => void;
+  setStreamScope: (streamScope: StreamScope) => void;
   resetState: () => void;
 }
 

--- a/packages/studio/src/components/AddPageButton/AddPageContextProvider.tsx
+++ b/packages/studio/src/components/AddPageButton/AddPageContextProvider.tsx
@@ -3,6 +3,7 @@ import AddPageContext, {
   AddPageContextValue,
   AddPageData,
 } from "./AddPageContext";
+import { StreamScope } from "@yext/studio-plugin";
 
 const initialPageData: AddPageData = {
   isStatic: true,
@@ -15,8 +16,9 @@ export default function AddPageContextProvider(props: PropsWithChildren) {
     () => ({
       state,
       actions: {
-        setIsStatic: (isStatic: boolean) =>
-          setState({ ...state, isStatic: isStatic }),
+        setIsStatic: (isStatic: boolean) => setState({ ...state, isStatic }),
+        setStreamScope: (streamScope: StreamScope) =>
+          setState({ ...state, streamScope }),
         resetState: () => setState(initialPageData),
       },
     }),

--- a/packages/studio/src/components/AddPageButton/BasicPageDataCollector.tsx
+++ b/packages/studio/src/components/AddPageButton/BasicPageDataCollector.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import FormModal from "../common/FormModal";
+import FormModal, { FormData } from "../common/FormModal";
 import { FlowStepModalProps } from "./FlowStep";
 import useStudioStore from "../../store/useStudioStore";
 
@@ -18,15 +18,15 @@ export default function BasicPageDataCollector({
     (store) => store.studioConfig.isPagesJSRepo
   );
 
-  const formDescriptions: BasicPageData = useMemo(
+  const formData: FormData<BasicPageData> = useMemo(
     () => ({
-      pageName: "Give the page a name:",
-      ...(isPagesJSRepo && { url: "Specify the URL slug:" }),
+      pageName: { description: "Give the page a name:" },
+      ...(isPagesJSRepo && { url: { description: "Specify the URL slug:" } }),
     }),
     [isPagesJSRepo]
   );
 
-  const handleSave = useCallback(
+  const onConfirm = useCallback(
     async (data: BasicPageData) => {
       try {
         await handleConfirm(data.pageName, data.url);
@@ -49,10 +49,10 @@ export default function BasicPageDataCollector({
     <FormModal
       isOpen={isOpen}
       title={modalTitle}
-      formDescriptions={formDescriptions}
+      formData={formData}
       errorMessage={errorMessage}
       handleClose={handleClose}
-      handleSave={handleSave}
+      handleConfirm={onConfirm}
     />
   );
 }

--- a/packages/studio/src/components/AddPageButton/FlowStep.ts
+++ b/packages/studio/src/components/AddPageButton/FlowStep.ts
@@ -1,8 +1,10 @@
 import BasicPageDataCollector from "./BasicPageDataCollector";
 import PageTypeSelector from "./PageTypeSelector";
+import StreamScopeCollector from "./StreamScopeCollector";
 
 export enum FlowStep {
   SelectPageType,
+  GetStreamScope,
   GetBasicPageData,
 }
 
@@ -18,5 +20,6 @@ type FlowStepModalMap = {
 
 export const flowStepModalMap: FlowStepModalMap = {
   [FlowStep.SelectPageType]: PageTypeSelector,
+  [FlowStep.GetStreamScope]: StreamScopeCollector,
   [FlowStep.GetBasicPageData]: BasicPageDataCollector,
 };

--- a/packages/studio/src/components/AddPageButton/StreamScopeCollector.tsx
+++ b/packages/studio/src/components/AddPageButton/StreamScopeCollector.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useContext } from "react";
+import FormModal, { FormData } from "../common/FormModal";
+import { FlowStepModalProps } from "./FlowStep";
+import { StreamScope } from "@yext/studio-plugin";
+import AddPageContext from "./AddPageContext";
+
+type StreamScopeForm = {
+  [key in keyof StreamScope]: string;
+};
+
+const formData: FormData<StreamScopeForm> = {
+  entityIds: {
+    description: "Entity IDs:",
+    optional: true,
+  },
+  entityTypes: {
+    description: "Entity Types:",
+    optional: true,
+  },
+  savedFilterIds: {
+    description: "Saved Filter IDs:",
+    optional: true,
+  },
+};
+
+export default function StreamScopeCollector({
+  isOpen,
+  handleClose,
+  handleConfirm,
+}: FlowStepModalProps) {
+  const { actions } = useContext(AddPageContext);
+
+  const onConfirm = useCallback(
+    async (data: StreamScopeForm) => {
+      const streamScope = Object.entries(data).reduce((scope, [key, val]) => {
+        const values = val
+          .split(",")
+          .map((str) => str.trim())
+          .filter((str) => str);
+        if (values.length > 0) {
+          scope[key] = values;
+        }
+        return scope;
+      }, {} as StreamScope);
+      actions.setStreamScope(streamScope);
+      await handleConfirm();
+      return true;
+    },
+    [handleConfirm, actions]
+  );
+
+  return (
+    <FormModal
+      isOpen={isOpen}
+      title="Specify the Stream Scope"
+      instructions="Use the optional fields below to define the scope of the
+        stream for the entity page. Values should be separated by commas."
+      formData={formData}
+      closeOnConfirm={false}
+      confirmButtonText="Next"
+      handleClose={handleClose}
+      handleConfirm={onConfirm}
+    />
+  );
+}

--- a/packages/studio/src/components/ModuleActions/CreateModuleButton.tsx
+++ b/packages/studio/src/components/ModuleActions/CreateModuleButton.tsx
@@ -1,4 +1,4 @@
-import FormModal from "../common/FormModal";
+import FormModal, { FormData } from "../common/FormModal";
 import ButtonWithModal, {
   renderModalFunction,
 } from "../common/ButtonWithModal";
@@ -8,8 +8,8 @@ import { ComponentStateKind } from "@yext/studio-plugin";
 
 type CreateModuleForm = { modulePath: string };
 
-const formDescriptions: CreateModuleForm = {
-  modulePath: "Give the module a name:",
+const formData: FormData<CreateModuleForm> = {
+  modulePath: { description: "Give the module a name:" },
 };
 
 /**
@@ -45,10 +45,10 @@ export default function CreateModuleButton(): JSX.Element | null {
         <FormModal
           isOpen={isOpen}
           title="Create Module"
-          formDescriptions={formDescriptions}
+          formData={formData}
           errorMessage={errorMessage}
           handleClose={handleClose}
-          handleSave={handleModalSave}
+          handleConfirm={handleModalSave}
         />
       );
     },

--- a/packages/studio/src/components/PageSettingsButton.tsx
+++ b/packages/studio/src/components/PageSettingsButton.tsx
@@ -2,7 +2,7 @@ import useStudioStore from "../store/useStudioStore";
 import { ReactComponent as Gear } from "../icons/gear.svg";
 import { useCallback, useMemo } from "react";
 import ButtonWithModal, { renderModalFunction } from "./common/ButtonWithModal";
-import FormModal from "./common/FormModal";
+import FormModal, { FormData } from "./common/FormModal";
 import { Tooltip } from "react-tooltip";
 import { GetPathVal, PropValueKind } from "@yext/studio-plugin";
 import TemplateExpressionFormatter from "../utils/TemplateExpressionFormatter";
@@ -12,8 +12,8 @@ type PageSettings = {
   url: string;
 };
 
-const formDescriptions: PageSettings = {
-  url: "URL slug:",
+const formData: FormData<PageSettings> = {
+  url: { description: "URL slug:" },
 };
 
 interface PageSettingsButtonProps {
@@ -64,10 +64,10 @@ export default function PageSettingsButton({
         <FormModal
           isOpen={isOpen}
           title="Page Settings"
-          formDescriptions={formDescriptions}
+          formData={formData}
           initialFormValue={initialFormValue}
           handleClose={handleClose}
-          handleSave={handleModalSave}
+          handleConfirm={handleModalSave}
           transformOnChangeValue={
             isEntityPage
               ? TemplateExpressionFormatter.convertCurlyBracesToSquareBrackets

--- a/packages/studio/src/store/StudioActions.ts
+++ b/packages/studio/src/store/StudioActions.ts
@@ -8,6 +8,7 @@ import {
   PropValueKind,
   PropValues,
   RepeaterState,
+  StreamScope,
   TypeGuards,
 } from "@yext/studio-plugin";
 import FileMetadataSlice from "./models/slices/FileMetadataSlice";
@@ -261,7 +262,11 @@ export default class StudioActions {
     };
   };
 
-  createPage = async (pageName: string, getPathValue?: string) => {
+  createPage = async (
+    pageName: string,
+    getPathValue?: string,
+    streamScope?: StreamScope
+  ) => {
     if (!pageName) {
       throw new Error("Error adding page: a pageName is required.");
     }
@@ -282,6 +287,7 @@ export default class StudioActions {
         getPathValue && {
           pagesJS: {
             getPathValue: { kind: PropValueKind.Literal, value: getPathValue },
+            ...(streamScope && { streamScope }),
           },
         }),
     });

--- a/packages/studio/tests/components/AddPageFlow/AddPageButton.test.tsx
+++ b/packages/studio/tests/components/AddPageFlow/AddPageButton.test.tsx
@@ -3,7 +3,13 @@ import userEvent from "@testing-library/user-event";
 import AddPageButton from "../../../src/components/AddPageButton/AddPageButton";
 import useStudioStore from "../../../src/store/useStudioStore";
 import mockStore from "../../__utils__/mockStore";
-import { PropValueKind } from "@yext/studio-plugin";
+import { PageState, PropValueKind } from "@yext/studio-plugin";
+
+const basicPageState: PageState = {
+  componentTree: [],
+  cssImports: [],
+  filepath: expect.stringContaining("test.tsx"),
+};
 
 beforeEach(() => {
   mockStore({
@@ -28,20 +34,32 @@ it("closes the modal when a page name is added in a non-PagesJS repo", async () 
   await userEvent.type(textbox, "test");
   const saveButton = screen.getByRole("button", { name: "Save" });
   await userEvent.click(saveButton);
-  expect(addPageSpy).toBeCalledWith("test", {
-    componentTree: [],
-    cssImports: [],
-    filepath: expect.stringContaining("test.tsx"),
-  });
+  expect(addPageSpy).toBeCalledWith("test", basicPageState);
   await waitFor(() => expect(screen.queryByText("Save")).toBeNull());
 });
 
 describe("PagesJS repo", () => {
-  it("closes the modal when page type, name, and url are specified for a static page", async () => {
+  beforeEach(() => {
     const originalStudioConfig = useStudioStore.getState().studioConfig;
     mockStore({
       studioConfig: { ...originalStudioConfig, isPagesJSRepo: true },
     });
+  });
+
+  async function specifyNameAndUrl() {
+    const nameTextbox = screen.getByRole("textbox", {
+      name: "Give the page a name:",
+    });
+    await userEvent.type(nameTextbox, "test");
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    expect(saveButton).toBeDisabled();
+    const urlTextbox = screen.getByRole("textbox", {
+      name: "Specify the URL slug:",
+    });
+    await userEvent.type(urlTextbox, "testing");
+  }
+
+  it("closes modal when page type, name, and url are specified for static page", async () => {
     const addPageSpy = jest.spyOn(useStudioStore.getState().pages, "addPage");
     render(<AddPageButton />);
 
@@ -53,27 +71,82 @@ describe("PagesJS repo", () => {
     const nextButton = screen.getByRole("button", { name: "Next" });
     await userEvent.click(nextButton);
 
-    const nameTextbox = screen.getByRole("textbox", {
-      name: "Give the page a name:",
-    });
-    await userEvent.type(nameTextbox, "test");
+    await specifyNameAndUrl();
     const saveButton = screen.getByRole("button", { name: "Save" });
-    expect(saveButton).toBeDisabled();
-    const urlTextbox = screen.getByRole("textbox", {
-      name: "Specify the URL slug:",
-    });
-    await userEvent.type(urlTextbox, "testing");
     await userEvent.click(saveButton);
 
     expect(addPageSpy).toBeCalledWith("test", {
-      componentTree: [],
-      cssImports: [],
-      filepath: expect.stringContaining("test.tsx"),
+      ...basicPageState,
       pagesJS: {
         getPathValue: { kind: PropValueKind.Literal, value: "testing" },
       },
     });
     await waitFor(() => expect(screen.queryByText("Save")).toBeNull());
+  });
+
+  describe("entity page", () => {
+    async function selectEntityPageType() {
+      const entityRadioButton = screen.getByRole("radio", { checked: false });
+      expect(entityRadioButton).toHaveAttribute("name", "Entity");
+      await userEvent.click(entityRadioButton);
+      const nextButton = screen.getByRole("button", { name: "Next" });
+      await userEvent.click(nextButton);
+    }
+
+    it("closes modal once page type, stream scope, name, and url are specified", async () => {
+      const addPageSpy = jest.spyOn(useStudioStore.getState().pages, "addPage");
+      render(<AddPageButton />);
+
+      const addPageButton = screen.getByRole("button");
+      await userEvent.click(addPageButton);
+
+      await selectEntityPageType();
+
+      const nextButton = screen.getByRole("button", { name: "Next" });
+      const entityTypesTextbox = screen.getByRole("textbox", {
+        name: "Entity Types:",
+      });
+      await userEvent.type(entityTypesTextbox, "location, restaurant");
+      await userEvent.click(nextButton);
+
+      await specifyNameAndUrl();
+      const saveButton = screen.getByRole("button", { name: "Save" });
+      await userEvent.click(saveButton);
+
+      expect(addPageSpy).toBeCalledWith("test", {
+        ...basicPageState,
+        pagesJS: {
+          getPathValue: { kind: PropValueKind.Literal, value: "testing" },
+          streamScope: { entityTypes: ["location", "restaurant"] },
+        },
+      });
+      await waitFor(() => expect(screen.queryByText("Save")).toBeNull());
+    });
+
+    it("does not require any filters for stream scope", async () => {
+      const addPageSpy = jest.spyOn(useStudioStore.getState().pages, "addPage");
+      render(<AddPageButton />);
+
+      const addPageButton = screen.getByRole("button");
+      await userEvent.click(addPageButton);
+
+      await selectEntityPageType();
+
+      const nextButton = screen.getByRole("button", { name: "Next" });
+      await userEvent.click(nextButton);
+
+      await specifyNameAndUrl();
+      const saveButton = screen.getByRole("button", { name: "Save" });
+      await userEvent.click(saveButton);
+
+      expect(addPageSpy).toBeCalledWith("test", {
+        ...basicPageState,
+        pagesJS: {
+          getPathValue: { kind: PropValueKind.Literal, value: "testing" },
+          streamScope: {},
+        },
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Add a modal in the page creation flow for specifying the scope of the stream for entity pages. None of the fields for the stream scope are required, so all fields in the modal are optional. String input values are considered to be comma-separated lists.

This PR also includes a small fix so that the `document` param isn't added for a page component if it doesn't use any stream expressions.

J=SLAP-2728
TEST=auto, manual

In the test-site, saw that the stream scope can only be specified in a PagesJS repo when the entity page type is selected. Tested specifying stream scope with zero, one, and multiple filter values.