### PR TITLE
Use file extension when invoking Vite from Studio binary.

### DIFF
--- a/packages/studio/bin/studio.ts
+++ b/packages/studio/bin/studio.ts
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 execSync(
-  "node --experimental-specifier-resolution=node node_modules/.bin/vite --config " +
+  "node --experimental-specifier-resolution=node node_modules/vite/bin/vite.js --config " +
     path.resolve(__dirname, "../../vite.config.ts"),
   { stdio: "inherit" }
 );


### PR DESCRIPTION
This PR Updates the Studio binary so that Node invokes `node_modules/vite/bin/vite.js` rather than `node_modules/.bin/vite`. On Windows, `.bin/vite` is actually a Shell script. This causes Node's module resolution to fail.

J=SLAP-2749
TEST=manual

Verifeid that the Studio binary correctly spins up Studio on both Unix and Windows.