### PR TITLE
fix GitWrapper try catch

### DIFF
--- a/packages/studio-plugin/src/git/GitWrapper.ts
+++ b/packages/studio-plugin/src/git/GitWrapper.ts
@@ -58,7 +58,7 @@ export default class GitWrapper {
           reason: "No changes to push.",
         };
       }
-  
+
       return {
         status: true,
       };

--- a/packages/studio-plugin/tests/git/GitWrapper.test.ts
+++ b/packages/studio-plugin/tests/git/GitWrapper.test.ts
@@ -41,6 +41,17 @@ describe("verifying canPush calculation", () => {
 
   const gitWrapper = new GitWrapper(mockedGitInstance);
 
+  it("handles arbitrarily thrown errors correctly", async () => {
+    jest.spyOn(mockedGitInstance, "getRemotes").mockImplementation(() => {
+      throw new Error("Arbitrary error");
+    });
+    await gitWrapper.refreshData();
+    expect(gitWrapper.getStoredData()?.canPush).toEqual({
+      reason: "Arbitrary error",
+      status: false,
+    });
+  });
+
   it("handles no remotes correctly", async () => {
     gitRemotesSpy.mockReturnValue(getResponseWithRemotes([]));
     await gitWrapper.refreshData();


### PR DESCRIPTION
The try catch was not working as expected, and when an error was thrown instead of updating the canPush to false and setting the error's message as the reason, instead the stored gitData would be set to undefined.

This would cause the page to crash on load. The error I was experiencing while working on Windows compatibility was
`Error: fatal: no upstream configured for branch '<branchName>`.
This error is now properly handled.

J=SLAP-2774
TEST=manual,auto

the error is handled as expected now
new unit test