### PR TITLE
Correct width of Drag Placeholder.

### DIFF
--- a/packages/studio/src/components/ComponentTree.tsx
+++ b/packages/studio/src/components/ComponentTree.tsx
@@ -122,7 +122,10 @@ function renderDragPreview(
 
 function renderPlaceholder(_: NodeModel, { depth }: PlaceholderRenderParams) {
   const Placeholder = () => {
-    const placeHolderStyle = useMemo(() => ({ left: `${depth}em`, width:`calc(100% - ${depth}em)` }), []);
+    const placeHolderStyle = useMemo(
+      () => ({ left: `${depth}em`, width: `calc(100% - ${depth}em)` }),
+      []
+    );
     return (
       <div
         className="bg-rose-500 absolute h-0.5 z-10"


### PR DESCRIPTION
In the `ComponentTree`, we had incorrectly styled the Drag Placeholder. As you moved through the layers of the tree, we correctly increase the `left` CSS property. But, we were not decreasing the width of the Placeholder accordingly. This meant the red line associated with the Placeholder would stick out into the Page Preview for sufficiently nested Components.

This PR ensures that whenever we indent the Placeholder to the left, we reduce its width by the same amount.

J=SLAP-2800
TEST=manual