### PR TITLE
Split out prop inputs

### DIFF
--- a/packages/studio/src/components/StringPropInput.tsx
+++ b/packages/studio/src/components/StringPropInput.tsx
@@ -1,0 +1,62 @@
+import { PropValueKind, PropValueType, TypeGuards } from "@yext/studio-plugin";
+import { ChangeEvent, useCallback } from "react";
+import TemplateExpressionFormatter from "../utils/TemplateExpressionFormatter";
+import FieldPickerInput from "./FieldPicker/FieldPickerInput";
+
+interface StringPropInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  propKind: PropValueKind;
+}
+
+/**
+ * Renders the input element of a non-union string prop, that will update the
+ * corresponding prop's value for the active component based on a user's input.
+ */
+export default function StringPropInput({
+  value,
+  onChange,
+  propKind,
+}: StringPropInputProps): JSX.Element {
+  const handleChangeEvent = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const val =
+        propKind === PropValueKind.Expression
+          ? TemplateExpressionFormatter.getRawValue(e.target.value)
+          : e.target.value;
+      onChange(val);
+    },
+    [onChange, propKind]
+  );
+
+  const displayValue =
+    propKind === PropValueKind.Expression
+      ? TemplateExpressionFormatter.getTemplateStringDisplayValue(value)
+      : value;
+
+  const appendField = useCallback(
+    (fieldId: string) => {
+      const documentUsage = "${" + fieldId + "}";
+      const appendedValue = displayValue
+        ? `${displayValue} ${documentUsage}`
+        : documentUsage;
+      onChange(TemplateExpressionFormatter.getRawValue(appendedValue));
+    },
+    [displayValue, onChange]
+  );
+
+  const fieldPickerFilter = useCallback(
+    (value: unknown) =>
+      TypeGuards.valueMatchesPropType({ type: PropValueType.string }, value),
+    []
+  );
+
+  return (
+    <FieldPickerInput
+      onInputChange={handleChangeEvent}
+      handleFieldSelection={appendField}
+      displayValue={displayValue}
+      fieldFilter={fieldPickerFilter}
+    />
+  );
+}

--- a/packages/studio/src/components/UnionPropInput.tsx
+++ b/packages/studio/src/components/UnionPropInput.tsx
@@ -1,0 +1,44 @@
+import { ChangeEvent, useCallback } from "react";
+
+interface UnionPropInputProps {
+  unionValues: string[];
+  propValue: string;
+  onChange: (value: string) => void;
+}
+
+const selectCssClasses =
+  "bg-gray-50 border border-gray-300 text-gray-900 rounded-lg focus:ring-blue-500 focus:border-blue-500 p-2.5";
+
+/**
+ * Renders the dropdown for a string union prop, that will update the
+ * corresponding prop's value for the active component based on the user's
+ * selection.
+ */
+export default function UnionPropInput({
+  unionValues,
+  propValue,
+  onChange,
+}: UnionPropInputProps): JSX.Element {
+  const handleChangeEvent = useCallback(
+    (e: ChangeEvent<HTMLSelectElement>) => {
+      onChange(e.target.value);
+    },
+    [onChange]
+  );
+
+  return (
+    <select
+      onChange={handleChangeEvent}
+      className={selectCssClasses}
+      value={propValue}
+    >
+      {unionValues.map((val) => {
+        return (
+          <option value={val} key={val}>
+            {val}
+          </option>
+        );
+      })}
+    </select>
+  );
+}


### PR DESCRIPTION
Separate the rendering of string and union prop inputs out of `PropInput` with new `StringPropInput` and `UnionPropInput` components. This simplifies `PropInput` so it isn't doing as much type-specific logic.

J=SLAP-2810
TEST=manual

See that the inputs for string props and union props look the same in the test-site.