### PR TITLE
Remove vite-ignores in studio-plugin dynamic imports

### DIFF
--- a/packages/studio-plugin/src/utils/dynamicImport.ts
+++ b/packages/studio-plugin/src/utils/dynamicImport.ts
@@ -5,13 +5,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export function dynamicImport(absFilepath: string): Promise<unknown> {
   const relativeFilepath = getWindowsCompatiblePath(absFilepath);
-  return import(/* @vite-ignore */ relativeFilepath);
+  return import(relativeFilepath);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function dynamicImportJson(absFilepath: string): Promise<any> {
   const relativeFilepath = getWindowsCompatiblePath(absFilepath);
-  const importedModule = await import(/* @vite-ignore */ relativeFilepath, {
+  const importedModule = await import(relativeFilepath, {
     assert: { type: "json" },
   });
   return importedModule.default;


### PR DESCRIPTION
We don't need these vite ignores, because in studio-plugin vite isn't actually doing anything to the imports.
These are just regular nodejs imports. We still need these in the frontend.

I did some digging to see how vite handles dynamic imports in the browser.
These don't result in code changes but I thought it would good to document them here.

In browser dynamic imports, vite will add an injectQuery call to any imports it can't statically analyze.
![image-20230713-154412](https://github.com/yext/studio-prototype/assets/23005393/92fd891c-ef34-4434-9b20-54c04bafd0ff)

This is what injectQuery is doing under the hood. I added a console log.
![image-20230713-154454](https://github.com/yext/studio-prototype/assets/23005393/e9156c48-73a7-4e57-882d-69090f05e7f3)

This is what the console log looks like. It
![image-20230713-154429](https://github.com/yext/studio-prototype/assets/23005393/6c85752d-39e0-4f3e-a401-9e648f464e8a)

For dynamic imports that vite IS able to statically analyze, this is what happens to them

This:
![image](https://github.com/yext/studio-prototype/assets/23005393/3e109071-231f-4338-9fae-b354da9e8b64)

Turns into:
![image](https://github.com/yext/studio-prototype/assets/23005393/9859582d-8992-4c99-87c4-5faa1a5b5ac5)

This is (unsurprisingly) consistent with what their docs say at https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations

J=SLAP-2779
TEST=manual

no warnings from vite about imports