### PR TITLE
Add __playground-* folders to gitignore

### DIFF
--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -1,3 +1,4 @@
 /test-results/
 /playwright-report/
 /playwright/.cache/
+__playground-*


### PR DESCRIPTION
This PR adds the playground folders to the e2e-test .gitignore. Originally I intentionally didn't do this
so that if cleanup wasn't allowed to finish (or debug mode turned off) it would be easier to remember
to manually clean up these folders. However I saw this was confusing some newer team members.

J=NONE
TEST=manual

I no longer see this folders in my changed files while the tests are running
