### PR TITLE
Bump version of studio and studio-plugin to v0.15.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22897,7 +22897,7 @@
     },
     "packages/studio": {
       "name": "@yext/studio",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@dhmk/zustand-lens": "^2.0.5",
         "@minoru/react-dnd-treeview": "^3.4.1",
@@ -22947,7 +22947,7 @@
     },
     "packages/studio-plugin": {
       "name": "@yext/studio-plugin",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@babel/parser": "^7.21.8",
         "@babel/preset-env": "^7.22.4",

--- a/packages/studio-plugin/package.json
+++ b/packages/studio-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/studio-plugin",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "types": "./lib/index.d.ts",
   "main": "./lib/index.js",
   "type": "module",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/studio",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "types": "./lib/types.d.ts",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Features
- First-class support for unsetting Optional Props in the Studio UI. (#273, #275, #272, #268, #265, #271, #274)

## Changes
- Repeaters are now deprecated. You cannot enable or disable Repeaters in the Studio UI. (#290)
- Copy changes for the Page Creation Modal. (#255)
- "Containers" verbiage was replaced with "Layouts". (#266)
- Added Acceptance & Visual Regression Tests for Windows. (#284)
- Acceptance Tests for Creation of Static (#257) and Entity (#262) Pages.
- The Page Preview is now contained inside an iFrame, addressing a number of Studio UI bugs. (#278)
- Improvements to our Testing Infrastructure. (#277, #264, #263, #267). 

## Bug Fixes
- Addressed an edge-case that caused Prop Tooltips not to appear. (#287)
- Fixed a bug that occurred when resetting the Color Picker. (#286)