### PR TITLE
Use Vite's open config option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5984,16 +5984,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/clean-css": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.6.tgz",
-      "integrity": "sha512-Ze1tf+LnGPmG6hBFMi0B4TEB0mhF7EiMM5oyjLDNPE9hxrPU0W+5+bHvO+eFPA+bt0iC1zkQMoU/iGdRVjcRbw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -6073,32 +6063,10 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/html-minifier": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-4.0.2.tgz",
-      "integrity": "sha512-4IkmkXJP/25R2fZsCHDX2abztXuQRzUAZq39PfCMz2loLFj8vS9y7aF6vDl58koXSTpsF+eL4Lc5Y4Aww/GCTQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/clean-css": "*",
-        "@types/relateurl": "*",
-        "@types/uglify-js": "*"
-      }
-    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
       "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg=="
-    },
-    "node_modules/@types/html-webpack-plugin": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@types/html-webpack-plugin/-/html-webpack-plugin-3.2.6.tgz",
-      "integrity": "sha512-U8uJSvlf9lwrKG6sKFnMhqY4qJw2QXad+PHlX9sqEXVUMilVt96aVvFde73tzsdXD+QH9JS6kEytuGO2JcYZog==",
-      "dev": true,
-      "dependencies": {
-        "@types/html-minifier": "*",
-        "@types/tapable": "^1",
-        "@types/webpack": "^4"
-      }
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.9",
@@ -6273,19 +6241,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@types/react-dev-utils": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dev-utils/-/react-dev-utils-9.0.11.tgz",
-      "integrity": "sha512-SdHtle/1hyImI1VzJUp20pthFwHY2O0Pq5QWIbPyku0SboPxqbyfwFwOlrr5d4yiZRr1in7SQ4Z0IiJVrJiJrg==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/express": "*",
-        "@types/html-webpack-plugin": "*",
-        "@types/webpack": "^4",
-        "@types/webpack-dev-server": "3"
-      }
-    },
     "node_modules/@types/react-dom": {
       "version": "18.0.10",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
@@ -6303,12 +6258,6 @@
       "dependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/relateurl": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.29.tgz",
-      "integrity": "sha512-QSvevZ+IRww2ldtfv1QskYsqVVVwCKQf1XbwtcyyoRvLIQzfyPhj/C+3+PKzSDRdiyejaiLgnq//XTkleorpLg==",
-      "dev": true
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -6362,7 +6311,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
       "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
-      "devOptional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -6373,7 +6323,8 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
-      "devOptional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.5",
@@ -6399,7 +6350,8 @@
       "version": "3.17.1",
       "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.1.tgz",
       "integrity": "sha512-GkewRA4i5oXacU/n4MA9+bLgt5/L3F1mKrYvFGm7r2ouLXhRKjuWwo9XHNnbx6WF3vlGW21S3fCvgqxvxXXc5g==",
-      "devOptional": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "source-map": "^0.6.1"
       }
@@ -6419,7 +6371,8 @@
       "version": "4.41.33",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.33.tgz",
       "integrity": "sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==",
-      "devOptional": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/tapable": "^1",
@@ -6429,24 +6382,12 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/@types/webpack-dev-server": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/@types/webpack-dev-server/-/webpack-dev-server-3.11.6.tgz",
-      "integrity": "sha512-XCph0RiiqFGetukCTC3KVnY1jwLcZ84illFRMbyFzCcWl90B/76ew0tSqF46oBhnLC4obNDG7dMO0JfTN0MgMQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/connect-history-api-fallback": "*",
-        "@types/express": "*",
-        "@types/serve-static": "*",
-        "@types/webpack": "^4",
-        "http-proxy-middleware": "^1.0.0"
-      }
-    },
     "node_modules/@types/webpack-sources": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.0.tgz",
       "integrity": "sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==",
-      "devOptional": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/source-list-map": "*",
@@ -6457,7 +6398,8 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
       "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "devOptional": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -12401,22 +12343,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/http-proxy-middleware": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.3.1.tgz",
-      "integrity": "sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==",
-      "dev": true,
-      "dependencies": {
-        "@types/http-proxy": "^1.17.5",
-        "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -22957,7 +22883,6 @@
         "camelcase": "^7.0.1",
         "colors": "^1.4.0",
         "prettier": "^2.8.1",
-        "react-dev-utils": "^12.0.1",
         "simple-git": "^3.16.0",
         "true-myth": "^6.2.0",
         "ts-morph": "^18.0.0",
@@ -22968,7 +22893,6 @@
       "devDependencies": {
         "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "@types/jest": "^29.2.4",
-        "@types/react-dev-utils": "^9.0.11",
         "@types/uuid": "^9.0.0",
         "@yext/search-ui-react": "1.1.0",
         "babel-plugin-transform-import-meta": "^2.2.0",

--- a/packages/studio-plugin/package.json
+++ b/packages/studio-plugin/package.json
@@ -37,7 +37,6 @@
     "camelcase": "^7.0.1",
     "colors": "^1.4.0",
     "prettier": "^2.8.1",
-    "react-dev-utils": "^12.0.1",
     "simple-git": "^3.16.0",
     "true-myth": "^6.2.0",
     "ts-morph": "^18.0.0",
@@ -51,7 +50,6 @@
   "devDependencies": {
     "@babel/plugin-syntax-import-assertions": "^7.20.0",
     "@types/jest": "^29.2.4",
-    "@types/react-dev-utils": "^9.0.11",
     "@types/uuid": "^9.0.0",
     "@yext/search-ui-react": "1.1.0",
     "babel-plugin-transform-import-meta": "^2.2.0",

--- a/packages/studio-plugin/src/createStudioPlugin.ts
+++ b/packages/studio-plugin/src/createStudioPlugin.ts
@@ -12,7 +12,6 @@ import GitWrapper from "./git/GitWrapper";
 import VirtualModuleID from "./VirtualModuleID";
 import HmrManager from "./HmrManager";
 import getLocalDataMapping from "./parsers/getLocalDataMapping";
-import openBrowser from "react-dev-utils/openBrowser";
 import { readdirSync, existsSync, lstatSync } from "fs";
 import upath from "upath";
 import lodash from "lodash";
@@ -69,13 +68,6 @@ export default async function createStudioPlugin(
   return {
     name: "yext-studio-vite-plugin",
     buildStart() {
-      if (
-        args.mode === "development" &&
-        args.command === "serve" &&
-        studioConfig.openBrowser
-      ) {
-        openBrowser(`http://localhost:${studioConfig.port}/`);
-      }
       const watchDir = (dirPath: string) => {
         if (existsSync(dirPath)) {
           readdirSync(dirPath).forEach((filename) => {
@@ -100,7 +92,10 @@ export default async function createStudioPlugin(
       const serverConfig: UserConfig = {
         server: {
           port: studioConfig.port,
-          strictPort: true,
+          open:
+            args.mode === "development" &&
+            args.command === "serve" &&
+            studioConfig.openBrowser,
         },
       };
       return lodash.merge({}, config, serverConfig);


### PR DESCRIPTION
This PR removes the manual call to open the browser when starting the Studio server. Instead, we can use Vite's `open` config option. This allows us to remove `strictPort` and the server will open on the next available port if the specified one is already in use.

J=SLAP-2763
TEST=manual

See that serving the test-site opens the browser as expected and when 5173 is occupied, 5174 is used. See that Playwright tests run locally without opening the browser.