### PR TITLE
Combine automated features.json sync with linting

### DIFF
--- a/.github/workflows/autofixes.yml
+++ b/.github/workflows/autofixes.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Automated Linting
         uses: EndBug/add-and-commit@v9
         with:
-          message: "Automated linting update"
+          message: "Automated linting update and features.json sync"
           add: "*"
           push: true
           pull: --rebase --autostash


### PR DESCRIPTION
The automated features.json sync needed to run linting anyways since the json output by npx pages generate features does not match our prettier setup.

J=None
TEST=None