### PR TITLE
Use unique stream ids

### DIFF
--- a/apps/test-site/sites-config/features.json
+++ b/apps/test-site/sites-config/features.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "LocationPage",
-      "streamId": "studio-stream-id",
+      "streamId": "studio-stream-id-LocationPage",
       "templateType": "JS",
       "entityPageSet": {
         "plugin": {}
@@ -24,7 +24,7 @@
     },
     {
       "name": "UniversalPage",
-      "streamId": "studio-stream-id",
+      "streamId": "studio-stream-id-UniversalPage",
       "templateType": "JS",
       "entityPageSet": {
         "plugin": {}
@@ -33,7 +33,7 @@
   ],
   "streams": [
     {
-      "$id": "studio-stream-id",
+      "$id": "studio-stream-id-LocationPage",
       "localization": {
         "locales": ["en"],
         "primary": false
@@ -44,7 +44,7 @@
       "fields": ["address", "hours", "slug"]
     },
     {
-      "$id": "studio-stream-id",
+      "$id": "studio-stream-id-UniversalPage",
       "localization": {
         "locales": ["en"],
         "primary": false

--- a/apps/test-site/src/templates/LocationPage.tsx
+++ b/apps/test-site/src/templates/LocationPage.tsx
@@ -7,7 +7,7 @@ import ProminentImage from "../components/ProminentImage";
 
 export const config: TemplateConfig = {
   stream: {
-    $id: "studio-stream-id",
+    $id: "studio-stream-id-LocationPage",
     localization: { locales: ["en"], primary: false },
     filter: { entityTypes: ["location"] },
     fields: ["address", "hours", "slug"],

--- a/apps/test-site/src/templates/UniversalPage.tsx
+++ b/apps/test-site/src/templates/UniversalPage.tsx
@@ -7,7 +7,7 @@ import FixedText from "../components/FixedText";
 
 export const config: TemplateConfig = {
   stream: {
-    $id: "studio-stream-id",
+    $id: "studio-stream-id-UniversalPage",
     localization: { locales: ["en"], primary: false },
     filter: {
       entityTypes: ["location"],

--- a/e2e-tests/tests/__fixtures__/add-entity-page-expected-page.tsx
+++ b/e2e-tests/tests/__fixtures__/add-entity-page-expected-page.tsx
@@ -2,7 +2,7 @@ import { GetPath, TemplateConfig, TemplateProps } from "@yext/pages";
 
 export const config: TemplateConfig = {
   stream: {
-    $id: "studio-stream-id",
+    $id: "studio-stream-id-EntityPage",
     localization: { locales: ["en"], primary: false },
     filter: {
       entityTypes: ["entity1"],

--- a/packages/studio-plugin/src/sourcefiles/PageFile.ts
+++ b/packages/studio-plugin/src/sourcefiles/PageFile.ts
@@ -64,7 +64,8 @@ export default class PageFile {
     this.templateConfigWriter = new TemplateConfigWriter(
       studioSourceFileWriter,
       templateConfigParser,
-      pagesJsWriter
+      pagesJsWriter,
+      pageComponentName
     );
     this.reactComponentFileWriter = new ReactComponentFileWriter(
       pageComponentName,

--- a/packages/studio-plugin/src/writers/TemplateConfigWriter.ts
+++ b/packages/studio-plugin/src/writers/TemplateConfigWriter.ts
@@ -26,7 +26,8 @@ export default class TemplateConfigWriter {
   constructor(
     private studioSourceFileWriter: StudioSourceFileWriter,
     private templateConfigParser: TemplateConfigParser,
-    private pagesJsWriter: PagesJsWriter
+    private pagesJsWriter: PagesJsWriter,
+    private pageName: string
   ) {}
 
   /**
@@ -82,7 +83,7 @@ export default class TemplateConfigWriter {
     return {
       ...currentTemplateConfig,
       stream: {
-        $id: "studio-stream-id",
+        $id: `studio-stream-id-${this.pageName}`,
         localization: STREAM_LOCALIZATION,
         ...currentTemplateConfig?.stream,
         filter: entityPageState.streamScope,

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/EmptyPageWithStreamConfigSlugField.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/EmptyPageWithStreamConfigSlugField.tsx
@@ -2,7 +2,7 @@ import { TemplateConfig, TemplateProps } from "@yext/pages";
 
 export const config: TemplateConfig = {
   stream: {
-    $id: "studio-stream-id",
+    $id: "studio-stream-id-test",
     localization: { locales: ["en"], primary: false },
     filter: {},
     fields: ["slug"],

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithComplexGetPath.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithComplexGetPath.tsx
@@ -2,7 +2,7 @@ import { GetPath, TemplateConfig, TemplateProps } from "@yext/pages";
 
 export const config: TemplateConfig = {
   stream: {
-    $id: "studio-stream-id",
+    $id: "studio-stream-id-test",
     localization: { locales: ["en"], primary: false },
     filter: {},
     fields: ["slug"],

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithErrorComponentState.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithErrorComponentState.tsx
@@ -2,7 +2,7 @@ import { TemplateConfig, TemplateProps } from "@yext/pages";
 
 export const config: TemplateConfig = {
   stream: {
-    $id: "studio-stream-id",
+    $id: "studio-stream-id-test",
     localization: { locales: ["en"], primary: false },
     filter: {},
     fields: ["name"],

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithGetPathStreamConfig.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithGetPathStreamConfig.tsx
@@ -3,7 +3,7 @@ import ComplexBanner from "../../ComponentFile/ComplexBanner";
 
 export const config: TemplateConfig = {
   stream: {
-    $id: "studio-stream-id",
+    $id: "studio-stream-id-test",
     localization: { locales: ["en"], primary: false },
     filter: {},
     fields: ["title", "city", "services"],

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithModifiedStreamScope.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithModifiedStreamScope.tsx
@@ -3,7 +3,7 @@ import ComplexBanner from "../../ComponentFile/ComplexBanner";
 
 export const config: TemplateConfig = {
   stream: {
-    $id: "studio-stream-id",
+    $id: "studio-stream-id-test",
     localization: { locales: ["en"], primary: false },
     filter: { entityTypes: ["product"] },
     fields: ["title"],

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithNoStreamPathsInTree.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithNoStreamPathsInTree.tsx
@@ -3,7 +3,7 @@ import ComplexBanner from "../../ComponentFile/ComplexBanner";
 
 export const config: TemplateConfig = {
   stream: {
-    $id: "studio-stream-id",
+    $id: "studio-stream-id-test",
     localization: { locales: ["en"], primary: false },
     filter: {},
     fields: ["slug"],

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithStreamConfig.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithStreamConfig.tsx
@@ -3,7 +3,7 @@ import ComplexBanner from "../../ComponentFile/ComplexBanner";
 
 export const config: TemplateConfig = {
   stream: {
-    $id: "studio-stream-id",
+    $id: "studio-stream-id-test",
     localization: { locales: ["en"], primary: false },
     filter: { entityTypes: ["location"] },
     fields: ["title"],

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithStreamConfigArrayAndObjectField.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithStreamConfigArrayAndObjectField.tsx
@@ -3,7 +3,7 @@ import ComplexBanner from "../../ComponentFile/ComplexBanner";
 
 export const config: TemplateConfig = {
   stream: {
-    $id: "studio-stream-id",
+    $id: "studio-stream-id-test",
     localization: { locales: ["en"], primary: false },
     filter: {},
     fields: ["arrayIndex", "objectField"],

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithStreamConfigMultipleFields.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithStreamConfigMultipleFields.tsx
@@ -3,7 +3,7 @@ import ComplexBanner from "../../ComponentFile/ComplexBanner";
 
 export const config: TemplateConfig = {
   stream: {
-    $id: "studio-stream-id",
+    $id: "studio-stream-id-test",
     localization: { locales: ["en"], primary: false },
     filter: {},
     fields: [

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithStreamConfigSlugField.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithStreamConfigSlugField.tsx
@@ -3,7 +3,7 @@ import ComplexBanner from "../../ComponentFile/ComplexBanner";
 
 export const config: TemplateConfig = {
   stream: {
-    $id: "studio-stream-id",
+    $id: "studio-stream-id-test",
     localization: { locales: ["en"], primary: false },
     filter: {},
     fields: ["title", "slug"],

--- a/packages/studio-plugin/tests/sourcefiles/PageFile.updatePageFile.test.ts
+++ b/packages/studio-plugin/tests/sourcefiles/PageFile.updatePageFile.test.ts
@@ -10,6 +10,7 @@ import { addFilesToProject } from "../__utils__/addFilesToProject";
 import { throwIfCalled } from "../__utils__/throwIfCalled";
 import { createTsMorphProject } from "../../src/ParsingOrchestrator";
 import { PageState } from "../../src/types/PageState";
+import upath from "upath";
 
 jest.mock("uuid");
 
@@ -58,6 +59,7 @@ describe("updatePageFile", () => {
   describe("template config", () => {
     beforeEach(() => {
       jest.spyOn(uuidUtils, "v4").mockReturnValue("mock-uuid-value");
+      jest.spyOn(upath, "basename").mockReturnValue("test");
     });
 
     it("adds template config variable when it is not already defined", () => {


### PR DESCRIPTION
For entity templates, the stream must have a unique id configured in the template config. Update TemplateConfigWriter to generate a unique id by incorporating the page name, which must be unique.

J=SLAP-2868
TEST=auto