### PR TITLE
Update run-tests.yml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        node-version: [16.x, 18.x, 19.x]
+        node-version: [18.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
For now, we should only test on Node 18. Node 16 is about to be fully deprecated and 19 is not stable. In the future, we should add Node 20 to the `node-version` array.