### PR TITLE
v0.17.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23141,7 +23141,7 @@
     },
     "packages/studio": {
       "name": "@yext/studio",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "dependencies": {
         "@dhmk/zustand-lens": "^2.0.5",
         "@minoru/react-dnd-treeview": "^3.4.1",
@@ -23190,7 +23190,7 @@
     },
     "packages/studio-plugin": {
       "name": "@yext/studio-plugin",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "dependencies": {
         "@babel/parser": "^7.21.8",
         "@babel/preset-env": "^7.22.4",

--- a/packages/studio-plugin/package.json
+++ b/packages/studio-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/studio-plugin",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "types": "./lib/index.d.ts",
   "main": "./lib/index.js",
   "type": "module",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/studio",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "types": "./lib/types.d.ts",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Features
- For Entity Templates, you can now pick which Entity is used in the preview. (#311)
- Props can now have Developer-specified display names. When specified, these appear in the Prop Editor in place of the variable name. (#307)
- The Delete key now removes the currently selected Component. (#293)
- When an Entity Template's Stream Scope is edited, we re-generate the Test Data. (#317)


## Changes
- Repeaters are now deprecated. You cannot enable or disable Repeaters in the Studio UI. (#290)
- A Prop's Name now appears above its value selector. (#302)

## Bug Fixes
- Re-generation of `localData` now works properly if you have multiple, unsaved Entity Templates. (#304)
- Re-generation of `localData` no longer can cause a full page refresh. (#304)
- Studio now generates unique Stream Ids for the Entity Templates it creates. (#314)
- Assorted UI fixes. (#288, #298)