### PR TITLE
Plugin: Prop Editors Don't Support Negative Numbers

### DIFF
--- a/packages/studio-plugin/src/parsers/helpers/StaticParsingHelpers.ts
+++ b/packages/studio-plugin/src/parsers/helpers/StaticParsingHelpers.ts
@@ -107,6 +107,7 @@ export default class StaticParsingHelpers {
         kind: PropValueKind.Literal,
       };
     }
+    console.log("hi");
     const expression = initializer.isKind(SyntaxKind.JsxExpression)
       ? initializer.getExpressionOrThrow()
       : initializer;
@@ -148,7 +149,7 @@ export default class StaticParsingHelpers {
       expression.getOperand().isKind(SyntaxKind.NumericLiteral)
     ) {
       return {
-        value: parseInt(expression.getOperand().toString()) * -1,
+        value: parseInt(expression.getOperand().getFullText()) * -1,
         kind: PropValueKind.Literal,
       };
     } else {

--- a/packages/studio-plugin/src/parsers/helpers/StaticParsingHelpers.ts
+++ b/packages/studio-plugin/src/parsers/helpers/StaticParsingHelpers.ts
@@ -107,7 +107,6 @@ export default class StaticParsingHelpers {
         kind: PropValueKind.Literal,
       };
     }
-    console.log("hi");
     const expression = initializer.isKind(SyntaxKind.JsxExpression)
       ? initializer.getExpressionOrThrow()
       : initializer;

--- a/packages/studio-plugin/src/parsers/helpers/StaticParsingHelpers.ts
+++ b/packages/studio-plugin/src/parsers/helpers/StaticParsingHelpers.ts
@@ -142,6 +142,15 @@ export default class StaticParsingHelpers {
           .filter((el): el is TypelessPropVal => el !== undefined),
         kind: PropValueKind.Literal,
       };
+    } else if (
+      expression.isKind(SyntaxKind.PrefixUnaryExpression) &&
+      expression.getOperatorToken() === SyntaxKind.MinusToken &&
+      expression.getOperand().isKind(SyntaxKind.NumericLiteral)
+    ) {
+      return {
+        value: parseInt(expression.getOperand().toString()) * -1,
+        kind: PropValueKind.Literal,
+      };
     } else {
       throw new Error(
         `Unrecognized prop value ${initializer.getFullText()} ` +

--- a/packages/studio-plugin/tests/parsers/StaticParsingHelpers.test.ts
+++ b/packages/studio-plugin/tests/parsers/StaticParsingHelpers.test.ts
@@ -56,6 +56,7 @@ describe("parseObjectLiteral", () => {
 describe("parseJsxAttributes", () => {
   const propShape: PropShape = {
     title: { type: PropValueType.string, tooltip: "jsdoc", required: false },
+    number: { type: PropValueType.number, required: false },
     nested: {
       type: PropValueType.Object,
       required: false,
@@ -201,6 +202,23 @@ describe("parseJsxAttributes", () => {
     };
     expect(receivedPropValues).toEqual(expectedPropValues);
   });
+
+  it("parsing an negative numeric literal", () => {
+    const sourceCode = `<Banner number={-1} />`;
+    const jsxAttributes = getJsxAttributesFromSource(sourceCode);
+    const receivedPropValues = StaticParsingHelpers.parseJsxAttributes(
+      jsxAttributes,
+      propShape
+    );
+    const expectedPropValues = {
+      number: {
+        kind: PropValueKind.Literal,
+        valueType: PropValueType.number,
+        value: -1,
+      },
+    };
+    expect(receivedPropValues).toEqual(expectedPropValues);
+  });
 });
 
 describe("unwrapParensExpression", () => {
@@ -301,22 +319,6 @@ describe("parseExportAssignment", () => {
     expect(() =>
       StaticParsingHelpers.parseExportAssignment(exportAssignment)
     ).toThrowError(/^Could not find a child of kind/);
-  });
-});
-
-it("parsing an negative numeric literal", () => {
-  const { sourceFile } = createTestSourceFile(`const a = { aKey: -1 }`);
-  const objectLiteralExpression = sourceFile.getFirstDescendantByKindOrThrow(
-    SyntaxKind.ObjectLiteralExpression
-  );
-  const parsedValue = StaticParsingHelpers.parseObjectLiteral(
-    objectLiteralExpression
-  );
-  expect(parsedValue).toEqual({
-    aKey: {
-      value: -1,
-      kind: PropValueKind.Literal,
-    },
   });
 });
 

--- a/packages/studio-plugin/tests/parsers/StaticParsingHelpers.test.ts
+++ b/packages/studio-plugin/tests/parsers/StaticParsingHelpers.test.ts
@@ -203,7 +203,7 @@ describe("parseJsxAttributes", () => {
     expect(receivedPropValues).toEqual(expectedPropValues);
   });
 
-  it("parsing an negative numeric literal", () => {
+  it("can parse a negative numeric literal", () => {
     const sourceCode = `<Banner number={-1} />`;
     const jsxAttributes = getJsxAttributesFromSource(sourceCode);
     const receivedPropValues = StaticParsingHelpers.parseJsxAttributes(

--- a/packages/studio-plugin/tests/parsers/StaticParsingHelpers.test.ts
+++ b/packages/studio-plugin/tests/parsers/StaticParsingHelpers.test.ts
@@ -304,6 +304,22 @@ describe("parseExportAssignment", () => {
   });
 });
 
+it("parsing an negative numeric literal", () => {
+  const { sourceFile } = createTestSourceFile(`const a = { aKey: -1 }`);
+  const objectLiteralExpression = sourceFile.getFirstDescendantByKindOrThrow(
+    SyntaxKind.ObjectLiteralExpression
+  );
+  const parsedValue = StaticParsingHelpers.parseObjectLiteral(
+    objectLiteralExpression
+  );
+  expect(parsedValue).toEqual({
+    aKey: {
+      value: -1,
+      kind: PropValueKind.Literal,
+    },
+  });
+});
+
 function getJsxAttributesFromSource(code: string): JsxAttributeLike[] {
   const { sourceFile } = createTestSourceFile(code);
   const jsxAttributes = sourceFile


### PR DESCRIPTION
Added an if else case for negative numbers. A SyntaxKind.NumericLiteral only accepts whole numbers, not negatives due to the operand. 

J=SLAP-2869
TEST=manual, auto 

Attempted using -1's in Cta, Banner, Buttons, and more components via right-side prop editor. 