### PR TITLE
Always sync entity files after generating test data

### DIFF
--- a/apps/test-site/package.json
+++ b/apps/test-site/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "dev": "studio",
-    "localData": "yext pages generate-test-data",
+    "localData": "yext pages generate-test-data -a",
     "start": "craco start",
     "build": "craco build"
   },

--- a/packages/studio-plugin/src/messaging/registerDeployListener.ts
+++ b/packages/studio-plugin/src/messaging/registerDeployListener.ts
@@ -1,5 +1,5 @@
 import { ViteDevServer } from "vite";
-import { MessageID, SaveChangesPayload } from "../types";
+import { MessageID, ResponseType, SaveChangesPayload } from "../types";
 import { registerListener } from "./registerListener";
 import executeSaveChanges from "./executeSaveChanges";
 import FileSystemManager from "../FileSystemManager";
@@ -20,7 +20,7 @@ export default function registerDeployListener(
       executeSaveChanges(saveData, fileManager, orchestrator);
       await gitWrapper.deploy();
       await reloadGitData(gitWrapper, server);
-      return { type: "success", msg: "Deployed successfully." };
+      return { type: ResponseType.Success, msg: "Deployed successfully." };
     }
   );
 }

--- a/packages/studio-plugin/src/messaging/registerListener.ts
+++ b/packages/studio-plugin/src/messaging/registerListener.ts
@@ -1,8 +1,9 @@
 import { ViteDevServer } from "vite";
 import {
-  ErrorResponse,
+  FatalErrorResponse,
   MessageID,
   ResponseEventMap,
+  ResponseType,
   StudioEventMap,
 } from "../types";
 import { IncomingMessage } from "http";
@@ -35,7 +36,7 @@ export function registerListener<T extends MessageID>(
 async function getResponsePayload<T extends MessageID>(
   messageId: T,
   handler: () => Promise<ResponseEventMap[T]> | ResponseEventMap[T]
-): Promise<ResponseEventMap[T] | ErrorResponse> {
+): Promise<ResponseEventMap[T] | FatalErrorResponse> {
   try {
     return handler();
   } catch (error: unknown) {
@@ -47,7 +48,7 @@ async function getResponsePayload<T extends MessageID>(
     }
     console.error(error);
     return {
-      type: "error",
+      type: ResponseType.Fatal,
       msg,
     };
   }

--- a/packages/studio-plugin/src/messaging/registerSaveChangesListener.ts
+++ b/packages/studio-plugin/src/messaging/registerSaveChangesListener.ts
@@ -3,7 +3,7 @@ import FileSystemManager from "../FileSystemManager";
 import GitWrapper from "../git/GitWrapper";
 import reloadGitData from "../git/reloadGitData";
 import ParsingOrchestrator from "../ParsingOrchestrator";
-import { MessageID, SaveChangesPayload } from "../types";
+import { MessageID, ResponseType, SaveChangesPayload } from "../types";
 import executeSaveChanges from "./executeSaveChanges";
 import { registerListener } from "./registerListener";
 
@@ -19,7 +19,7 @@ export default function registerSaveChangesListener(
     async (saveData: SaveChangesPayload) => {
       executeSaveChanges(saveData, fileManager, orchestrator);
       await reloadGitData(gitWrapper, server);
-      return { type: "success", msg: "Changes saved successfully." };
+      return { type: ResponseType.Success, msg: "Changes saved successfully." };
     }
   );
 }

--- a/packages/studio-plugin/src/types/messages.ts
+++ b/packages/studio-plugin/src/types/messages.ts
@@ -35,20 +35,31 @@ export type StudioEventMap = {
   [MessageID.GenerateTestData]: GenerateTestDataPayload;
 };
 
-type BaseResponse = {
-  type: "success";
+export enum ResponseType {
+  Success = "success",
+  Error = "error",
+  Fatal = "fatal",
+}
+
+export type BaseResponse = {
+  type: ResponseType.Success;
   msg: string;
 };
 
 export type ErrorResponse = {
-  type: "error";
+  type: ResponseType.Error;
+  msg: string;
+};
+
+export type FatalErrorResponse = {
+  type: ResponseType.Fatal;
   msg: string;
 };
 
 export type ResponseEventMap = {
   [MessageID.Deploy]: BaseResponse;
   [MessageID.SaveChanges]: BaseResponse;
-  [MessageID.GenerateTestData]: BaseResponse & {
+  [MessageID.GenerateTestData]: (BaseResponse | ErrorResponse) & {
     mappingJson: Record<string, string[]>;
   };
 };

--- a/packages/studio/src/components/PageSettingsButton/EntityPageModal.tsx
+++ b/packages/studio/src/components/PageSettingsButton/EntityPageModal.tsx
@@ -1,7 +1,7 @@
 import useStudioStore from "../../store/useStudioStore";
 import { useCallback, useMemo } from "react";
 import FormModal, { FormData } from "../common/FormModal";
-import { GetPathVal, PropValueKind } from "@yext/studio-plugin";
+import { GetPathVal, PropValueKind, ResponseType } from "@yext/studio-plugin";
 import TemplateExpressionFormatter from "../../utils/TemplateExpressionFormatter";
 import PropValueHelpers from "../../utils/PropValueHelpers";
 import StreamScopeParser, {
@@ -31,18 +31,12 @@ export default function EntityPageModal({
     streamScope,
     updateStreamScope,
     generateTestData,
-    updateEntityFiles,
-    setActiveEntityFile,
-    refreshActivePageEntities,
   ] = useStudioStore((store) => [
     store.pages.pages[pageName].pagesJS?.getPathValue,
     store.pages.updateGetPathValue,
     store.pages.pages[pageName].pagesJS?.streamScope,
     store.pages.updateStreamScope,
     store.actions.generateTestData,
-    store.pages.updateEntityFiles,
-    store.pages.setActiveEntityFile,
-    store.actions.refreshActivePageEntities,
   ]);
   const isPathUndefined = !currGetPathValue;
 
@@ -80,13 +74,9 @@ export default function EntityPageModal({
       const parsedForm = StreamScopeParser.parseStreamScope(form);
       updateStreamScope(pageName, parsedForm);
       const regenerateTestData = async () => {
-        try {
-          const mapping = await generateTestData();
-          updateEntityFiles(pageName, mapping[pageName]);
-          setActiveEntityFile(mapping[pageName]?.[0]);
-          await refreshActivePageEntities();
-        } catch {
-          toast.warn(
+        const response = await generateTestData();
+        if (response.type === ResponseType.Error) {
+          toast.error(
             "Error generating test data, but entity page settings were still updated."
           );
         }
@@ -102,9 +92,6 @@ export default function EntityPageModal({
       currGetPathValue,
       pageName,
       generateTestData,
-      updateEntityFiles,
-      setActiveEntityFile,
-      refreshActivePageEntities,
       streamScope,
     ]
   );

--- a/packages/studio/src/messaging/sendMessage.ts
+++ b/packages/studio/src/messaging/sendMessage.ts
@@ -1,7 +1,8 @@
 import {
-  ErrorResponse,
+  FatalErrorResponse,
   MessageID,
   ResponseEventMap,
+  ResponseType,
   StudioEventMap,
 } from "@yext/studio-plugin";
 import { toast } from "react-toastify";
@@ -13,21 +14,20 @@ import { toast } from "react-toastify";
  */
 export default async function sendMessage<T extends MessageID>(
   messageId: T,
-  payload: StudioEventMap[T],
-  options?: {
-    displayErrorToast?: boolean;
-  }
+  payload: StudioEventMap[T]
 ): Promise<ResponseEventMap[T]> {
   const response = await fetch(window.location.href + messageId, {
     method: "POST",
     body: JSON.stringify(payload),
   });
-  const responseData: ResponseEventMap[T] | ErrorResponse =
+  const responseData: ResponseEventMap[T] | FatalErrorResponse =
     await response.json();
-  if (responseData.type === "error") {
-    options?.displayErrorToast && toast.error(responseData.msg);
+  if (responseData.type === ResponseType.Fatal) {
+    toast.error(responseData.msg);
     throw new Error(responseData.msg);
   }
-  toast.success(responseData.msg);
+  if (responseData.type === ResponseType.Success) {
+    toast.success(responseData.msg);
+  }
   return responseData;
 }

--- a/packages/studio/src/store/StudioActions.ts
+++ b/packages/studio/src/store/StudioActions.ts
@@ -51,7 +51,8 @@ export default class StudioActions {
       getFileMetadatas
     ).importComponent;
     this.generateTestData = new GenerateTestDataAction(
-      getPages
+      getPages,
+      this
     ).generateTestData;
     this.createPage = new CreatePageAction(
       this,
@@ -233,6 +234,7 @@ export default class StudioActions {
     const entityFiles =
       this.getPages().getActivePageState()?.pagesJS?.entityFiles;
     if (!entityFiles?.length) {
+      this.getPages().setActivePageEntities(undefined);
       return;
     }
 

--- a/packages/studio/src/store/StudioActions/CreatePageAction.ts
+++ b/packages/studio/src/store/StudioActions/CreatePageAction.ts
@@ -3,6 +3,7 @@ import {
   StreamScope,
   PageState,
   PagesJsState,
+  ResponseType,
 } from "@yext/studio-plugin";
 import path from "path-browserify";
 import StudioConfigSlice from "../models/slices/StudioConfigSlice";
@@ -35,11 +36,11 @@ export default class CreatePageAction {
     this.getPageSlice().addPage(pageName, pageState);
 
     if (streamScope) {
-      try {
-        const mappingJson = await this.studioActions.generateTestData();
-        this.updateEntityFiles(pageName, mappingJson);
-      } catch {
-        toast.warn("Could not generate test data, but page was still created.");
+      const response = await this.studioActions.generateTestData();
+      if (response.type === ResponseType.Error) {
+        toast.error(
+          "Could not generate test data, but page was still created."
+        );
       }
     }
 
@@ -62,24 +63,6 @@ export default class CreatePageAction {
       pageState.pagesJS = pagesJsState;
     }
     return pageState;
-  }
-
-  private updateEntityFiles(
-    pageName: string,
-    mappingJson: Record<string, string[]>
-  ) {
-    const entityFilesForPage: string[] = mappingJson?.[pageName];
-    if (!Array.isArray(entityFilesForPage)) {
-      console.error(
-        `Error getting entity files for ${pageName} from ${JSON.stringify(
-          mappingJson,
-          null,
-          2
-        )}`
-      );
-    } else {
-      this.getPageSlice().updateEntityFiles(pageName, entityFilesForPage);
-    }
   }
 }
 

--- a/packages/studio/src/store/StudioActions/GenerateTestDataAction.ts
+++ b/packages/studio/src/store/StudioActions/GenerateTestDataAction.ts
@@ -4,15 +4,23 @@ import {
   EntityFeature,
   FeaturesJson,
   MessageID,
+  ResponseEventMap,
 } from "@yext/studio-plugin";
 import { Stream } from "@yext/pages";
 import PageSlice from "../models/slices/PageSlice";
 import sendMessage from "../../messaging/sendMessage";
+import { isEqual } from "lodash";
+import StudioActions from "../StudioActions";
 
 export default class GenerateTestDataAction {
-  constructor(private getPageSlice: () => PageSlice) {}
+  constructor(
+    private getPageSlice: () => PageSlice,
+    private studioActions: StudioActions
+  ) {}
 
-  generateTestData = async (): Promise<Record<string, string[]>> => {
+  generateTestData = async (): Promise<
+    ResponseEventMap["studio:generateTestData"]
+  > => {
     const featuresJson = Object.entries(
       this.getPageSlice().pages
     ).reduce<FeaturesJson>(
@@ -36,16 +44,28 @@ export default class GenerateTestDataAction {
         features: [],
       }
     );
-    const response = await sendMessage(
-      MessageID.GenerateTestData,
-      {
-        featuresJson,
-      },
-      {
-        displayErrorToast: false,
-      }
+    const response = await sendMessage(MessageID.GenerateTestData, {
+      featuresJson,
+    });
+    await this.updateEntityFiles(response.mappingJson);
+    return response;
+  };
+
+  private updateEntityFiles = async (mappingJson: Record<string, string[]>) => {
+    await Promise.all(
+      Object.entries(this.getPageSlice().pages).map(
+        async ([pageName, pageState]) => {
+          const entityFiles: string[] = mappingJson[pageName];
+          if (!isEqual(pageState.pagesJS?.entityFiles, entityFiles)) {
+            this.getPageSlice().setEntityFiles(pageName, entityFiles);
+            if (pageName === this.getPageSlice().activePageName) {
+              await this.studioActions.refreshActivePageEntities();
+              this.getPageSlice().setActiveEntityFile(entityFiles?.[0]);
+            }
+          }
+        }
+      )
     );
-    return response.mappingJson;
   };
 
   private static getStreamId(pageName: string) {

--- a/packages/studio/src/store/StudioActions/GenerateTestDataAction.ts
+++ b/packages/studio/src/store/StudioActions/GenerateTestDataAction.ts
@@ -56,7 +56,9 @@ export default class GenerateTestDataAction {
       Object.entries(this.getPageSlice().pages).map(
         async ([pageName, pageState]) => {
           const entityFiles: string[] = mappingJson[pageName];
-          if (!isEqual(pageState.pagesJS?.entityFiles, entityFiles)) {
+          const newEntityFilesSet = new Set(entityFiles);
+          const currEntityFilesSet = new Set(pageState.pagesJS?.entityFiles);
+          if (!isEqual(currEntityFilesSet, newEntityFilesSet)) {
             this.getPageSlice().setEntityFiles(pageName, entityFiles);
             if (pageName === this.getPageSlice().activePageName) {
               await this.studioActions.refreshActivePageEntities();

--- a/packages/studio/src/store/models/slices/PageSlice.ts
+++ b/packages/studio/src/store/models/slices/PageSlice.ts
@@ -61,7 +61,7 @@ interface PageSliceActions {
   ) => void;
   updateGetPathValue: (pageName: string, getPathValue: GetPathVal) => void;
   updateStreamScope: (pageName: string, newStreamScope: StreamScope) => void;
-  updateEntityFiles: (pageName: string, entityFiles: string[]) => void;
+  setEntityFiles: (pageName: string, entityFiles: string[] | undefined) => void;
 
   setActiveComponentUUID: (activeComponentUUID: string | undefined) => void;
   setActiveComponentRect: (rect: DOMRectProperties | undefined) => void;

--- a/packages/studio/src/store/slices/pages/createPageSlice.ts
+++ b/packages/studio/src/store/slices/pages/createPageSlice.ts
@@ -101,19 +101,18 @@ export const createPageSlice: SliceCreator<PageSlice> = (set, get) => {
         }
       });
     },
-    updateEntityFiles: (pageName: string, entityFiles: string[]) => {
+    setEntityFiles: (pageName: string, entityFiles: string[] | undefined) => {
       set((store) => {
         const pageState = store.pages[pageName];
         if (!pageState.pagesJS) {
           throw new Error(
-            `Tried to updateEntityFiles for non PagesJS page ${pageName}.`
+            `Tried to update entity files for non-PagesJS page ${pageName}.`
           );
         }
         pageState.pagesJS = {
           ...pageState.pagesJS,
           entityFiles,
         };
-        store.pendingChanges.pagesToUpdate.add(pageName);
       });
     },
     clearPendingChanges: () => {

--- a/packages/studio/tests/components/AddPageFlow/AddPageButton.test.tsx
+++ b/packages/studio/tests/components/AddPageFlow/AddPageButton.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import AddPageButton from "../../../src/components/AddPageButton/AddPageButton";
 import useStudioStore from "../../../src/store/useStudioStore";
 import mockStore from "../../__utils__/mockStore";
-import { PageState, PropValueKind } from "@yext/studio-plugin";
+import { PageState, PropValueKind, ResponseType } from "@yext/studio-plugin";
 import * as sendMessageModule from "../../../src/messaging/sendMessage";
 
 const basicPageState: PageState = {
@@ -123,7 +123,7 @@ describe("PagesJS repo", () => {
         return new Promise((resolve) =>
           resolve({
             msg: "msg",
-            type: "success",
+            type: ResponseType.Success,
             mappingJson: {
               test: ["mockLocalData.json"],
             },
@@ -172,7 +172,7 @@ describe("PagesJS repo", () => {
         return new Promise((resolve) =>
           resolve({
             msg: "msg",
-            type: "success",
+            type: ResponseType.Success,
             mappingJson: {
               test: ["mockLocalData.json"],
             },

--- a/packages/studio/tests/store/StudioActions/GenerateTestDataAction.test.ts
+++ b/packages/studio/tests/store/StudioActions/GenerateTestDataAction.test.ts
@@ -36,14 +36,17 @@ describe("updateEntityFiles", () => {
     expect(pageSlice.activePageEntities).toBeUndefined();
   });
 
-  it("does not update entityFiles if there was no change", async () => {
+  it("does not update entityFiles if there was no change except order", async () => {
     mockPageSliceStates({
-      pages: getPagesRecord(["mockLocalData.json"]),
+      pages: getPagesRecord(["mockLocalData.json", "entityFile.json"]),
       activePageName: "test",
       activeEntityFile: "mockLocalData.json",
-      activePageEntities: { "mockLocalData.json": { name: "test" } },
+      activePageEntities: {
+        "mockLocalData.json": { name: "test1" },
+        "entityFile.json": { name: "test2" },
+      },
     });
-    mockMessage({ test: ["mockLocalData.json"] });
+    mockMessage({ test: ["entityFile.json", "mockLocalData.json"] });
     const setEntityFilesSpy = jest.spyOn(
       useStudioStore.getState().pages,
       "setEntityFiles"
@@ -67,10 +70,12 @@ describe("updateEntityFiles", () => {
     const pageSlice = useStudioStore.getState().pages;
     expect(pageSlice.pages["test"].pagesJS?.entityFiles).toEqual([
       "mockLocalData.json",
+      "entityFile.json",
     ]);
     expect(pageSlice.activeEntityFile).toEqual("mockLocalData.json");
     expect(pageSlice.activePageEntities).toEqual({
-      "mockLocalData.json": { name: "test" },
+      "mockLocalData.json": { name: "test1" },
+      "entityFile.json": { name: "test2" },
     });
   });
 

--- a/packages/studio/tests/store/StudioActions/GenerateTestDataAction.test.ts
+++ b/packages/studio/tests/store/StudioActions/GenerateTestDataAction.test.ts
@@ -1,0 +1,115 @@
+import useStudioStore from "../../../src/store/useStudioStore";
+import { mockPageSliceStates } from "../../__utils__/mockPageSliceState";
+import * as sendMessageModule from "../../../src/messaging/sendMessage";
+import { ResponseType } from "@yext/studio-plugin";
+
+describe("updateEntityFiles", () => {
+  it("updates previously undefined entityFiles", async () => {
+    mockPageSliceStates({
+      pages: getPagesRecord(),
+      activePageName: "test",
+    });
+    mockMessage({ test: ["mockLocalData.json"] });
+    await useStudioStore.getState().actions.generateTestData();
+    const pageSlice = useStudioStore.getState().pages;
+    expect(pageSlice.pages["test"].pagesJS?.entityFiles).toEqual([
+      "mockLocalData.json",
+    ]);
+    expect(pageSlice.activeEntityFile).toEqual("mockLocalData.json");
+    expect(pageSlice.activePageEntities).toEqual({
+      "mockLocalData.json": expect.anything(),
+    });
+  });
+
+  it("updates entityFiles to undefined when no test data is generated", async () => {
+    mockPageSliceStates({
+      pages: getPagesRecord(["mockLocalData.json"]),
+      activePageName: "test",
+      activeEntityFile: "mockLocalData.json",
+      activePageEntities: { "mockLocalData.json": { name: "test" } },
+    });
+    mockMessage({}, true);
+    await useStudioStore.getState().actions.generateTestData();
+    const pageSlice = useStudioStore.getState().pages;
+    expect(pageSlice.pages["test"].pagesJS?.entityFiles).toBeUndefined();
+    expect(pageSlice.activeEntityFile).toBeUndefined();
+    expect(pageSlice.activePageEntities).toBeUndefined();
+  });
+
+  it("does not update entityFiles if there was no change", async () => {
+    mockPageSliceStates({
+      pages: getPagesRecord(["mockLocalData.json"]),
+      activePageName: "test",
+      activeEntityFile: "mockLocalData.json",
+      activePageEntities: { "mockLocalData.json": { name: "test" } },
+    });
+    mockMessage({ test: ["mockLocalData.json"] });
+    const setEntityFilesSpy = jest.spyOn(
+      useStudioStore.getState().pages,
+      "setEntityFiles"
+    );
+    const setActiveEntityFileSpy = jest.spyOn(
+      useStudioStore.getState().pages,
+      "setActiveEntityFile"
+    );
+    const setActivePageEntitiesSpy = jest.spyOn(
+      useStudioStore.getState().pages,
+      "setActivePageEntities"
+    );
+    const spies = [
+      setEntityFilesSpy,
+      setActiveEntityFileSpy,
+      setActivePageEntitiesSpy,
+    ];
+    spies.forEach((spy) => expect(spy).toBeCalledTimes(0));
+    await useStudioStore.getState().actions.generateTestData();
+    spies.forEach((spy) => expect(spy).toBeCalledTimes(0));
+    const pageSlice = useStudioStore.getState().pages;
+    expect(pageSlice.pages["test"].pagesJS?.entityFiles).toEqual([
+      "mockLocalData.json",
+    ]);
+    expect(pageSlice.activeEntityFile).toEqual("mockLocalData.json");
+    expect(pageSlice.activePageEntities).toEqual({
+      "mockLocalData.json": { name: "test" },
+    });
+  });
+
+  it("does not update active entities if only data for non-active pages are regenerated", async () => {
+    mockPageSliceStates({ pages: getPagesRecord() });
+    mockMessage({ test: ["mockLocalData.json"] });
+    await useStudioStore.getState().actions.generateTestData();
+    const pageSlice = useStudioStore.getState().pages;
+    expect(pageSlice.pages["test"].pagesJS?.entityFiles).toEqual([
+      "mockLocalData.json",
+    ]);
+    expect(pageSlice.activeEntityFile).toBeUndefined();
+    expect(pageSlice.activePageEntities).toBeUndefined();
+  });
+});
+
+function mockMessage(mappingJson: Record<string, string[]>, isError = false) {
+  jest.spyOn(sendMessageModule, "default").mockImplementation(() => {
+    return new Promise((resolve) =>
+      resolve({
+        msg: "msg",
+        type: isError ? ResponseType.Error : ResponseType.Success,
+        mappingJson,
+      })
+    );
+  });
+}
+
+function getPagesRecord(entityFiles?: string[]) {
+  return {
+    test: {
+      componentTree: [],
+      cssImports: [],
+      filepath: "mock-filepath",
+      pagesJS: {
+        getPathValue: undefined,
+        streamScope: {},
+        entityFiles,
+      },
+    },
+  };
+}

--- a/packages/studio/tests/store/StudioActions/refreshActivePageEntities.test.ts
+++ b/packages/studio/tests/store/StudioActions/refreshActivePageEntities.test.ts
@@ -49,8 +49,17 @@ describe("refreshActivePageEntities", () => {
   });
 
   it("sets activePageEntities to undefined if there are no entityFiles", async () => {
-    await useStudioStore.getState().actions.updateActivePage("empty");
     await useStudioStore.getState().actions.refreshActivePageEntities();
+    expect(
+      useStudioStore.getState().pages.activePageEntities
+    ).not.toBeUndefined();
+    const refreshEntitiesSpy = jest.spyOn(
+      useStudioStore.getState().actions,
+      "refreshActivePageEntities"
+    );
+    expect(refreshEntitiesSpy).toBeCalledTimes(0);
+    await useStudioStore.getState().actions.updateActivePage("empty");
+    expect(refreshEntitiesSpy).toBeCalledTimes(1);
     expect(useStudioStore.getState().pages.activePageEntities).toBeUndefined();
   });
 


### PR DESCRIPTION
This PR updates our test data generation flow so that even if the generation returns a non-zero exit code, we still pass the resulting `mapping.json` to studio. The store is updated based on the new state of the `localData` directory. Also, toast messages were changed from a warning to an error because currently the main use case for Studio is for developing dynamic entity templates, so a problem in the test data is a major issue that should likely result in the user exiting out of the UI.

This PR also updates the test-site's `localData` script so it pulls all test data fields with the `-a` flag, and it fixes a couple bugs
- When `entityFiles` for the active page are undefined, `refreshActivePageEntities` changes the `activePageEntities` to undefined, instead of just returning without making any updates
- When the stream scope for a non-active page is updated and test data is regenerated, we don't don't update the `activeEntityFile` unless the test data for the active page has been changed. In that case, one of the active page's `entityFiles` is set as the new `activeEntityFile`, not an entity file from the edited page that triggered the test data generation

J=SLAP-2867
TEST=manual, auto

In the test-site, see that
- errored test data generation results in an error toast
- a new page with no test data after regeneration no longer shows the entity picker with entities from the previous active page
- regenerating test data when the stream scope for a non-active page is edited no longer gives a console error about incorrectly trying to update the activeEntityFile