### PR TITLE
Set debug to true for acceptance tests running in CI

### DIFF
--- a/e2e-tests/tests/infra/setupAcceptance.ts
+++ b/e2e-tests/tests/infra/setupAcceptance.ts
@@ -12,8 +12,6 @@ import killPort from "kill-port";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-console.log(process.env)
-
 /**
  * Spawns a studio instance for the test that will not be shared
  * with any other tests. This instance runs in a temporary folder.

--- a/e2e-tests/tests/infra/setupAcceptance.ts
+++ b/e2e-tests/tests/infra/setupAcceptance.ts
@@ -12,6 +12,8 @@ import killPort from "kill-port";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+console.log(process.env)
+
 /**
  * Spawns a studio instance for the test that will not be shared
  * with any other tests. This instance runs in a temporary folder.

--- a/e2e-tests/tests/infra/studioTest.ts
+++ b/e2e-tests/tests/infra/studioTest.ts
@@ -22,7 +22,7 @@ type Fixtures = {
  */
 export const studioTest = base.extend<Fixtures>({
   createRemote: false,
-  debug: false,
+  debug: !!process.env.CI,
   studioPage: async ({ page, createRemote, debug }, use, testInfo) => {
     const opts = { createRemote, debug, testInfo };
     await setupAcceptance(opts, async (port: number, tmpDir: string) => {


### PR DESCRIPTION
When running in CI, the debug flag is now given a default of true.
Tests in CI don't need to cleanup temp folders, and always run tests with only one worker thread
due to github runners only having two cores.

I think it still makes sense to have this off by default locally, because locally when we run tests in parallel
there's way too much output and it all gets squished together which isn't helpful.
If we did want to set debug to true by default locally, we'd need a separate flag for temp folder cleanup because we definitely want that to happen by default (locally).

J=SLAP-2877
TEST=auto

see logging in playwright actions for this PR
local tests still have debug: false