### PR TITLE
Update copy of `EntityPicker` Component.

### DIFF
--- a/packages/studio/src/components/EntityPicker.tsx
+++ b/packages/studio/src/components/EntityPicker.tsx
@@ -41,7 +41,7 @@ export default function EntityPicker(): JSX.Element | null {
         >
           {Object.entries(activePageEntities).map(([fileName, data]) => (
             <option key={fileName} value={fileName}>
-              {`Name: ${data.name}, ID: ${data.id}`}
+              {`${data.name} (id: ${data.id})`}
             </option>
           ))}
         </select>

--- a/packages/studio/tests/components/EntityPicker.test.tsx
+++ b/packages/studio/tests/components/EntityPicker.test.tsx
@@ -60,8 +60,8 @@ it("does not render if the page is not an entity page", async () => {
 it("correctly renders dropdown for entity page", () => {
   render(<EntityPicker />);
   expect(screen.getByLabelText("Entity")).toHaveValue("entityFile-1.json");
-  expect(screen.getByText("Name: Entity 1, ID: entity-1")).toBeDefined();
-  expect(screen.getByText("Name: Entity 2, ID: entity-2")).toBeDefined();
+  expect(screen.getByText("Entity 1 (id: entity-1)")).toBeDefined();
+  expect(screen.getByText("Entity 2 (id: entity-2)")).toBeDefined();
 });
 
 it("can update active entity using dropdown", async () => {


### PR DESCRIPTION
Product wanted us to change the display name for the `EntityPicker` options. They want the format to be:
`[Entity Name] (id: [Entity Id])`.

J=SLAP-2878
TEST=auto,manual