### PR TITLE
Include Static Pages in `GenerateTestData`

### DIFF
--- a/packages/studio-plugin/THIRD-PARTY-NOTICES
+++ b/packages/studio-plugin/THIRD-PARTY-NOTICES
@@ -4018,7 +4018,7 @@ THE SOFTWARE.
 
 The following npm package may be included in this product:
 
- - electron-to-chromium@1.4.491
+ - electron-to-chromium@1.4.492
 
 This package contains the following license and notice below:
 
@@ -7678,7 +7678,7 @@ THE SOFTWARE.
 
 The following npm package may be included in this product:
 
- - postcss@8.4.27
+ - postcss@8.4.28
 
 This package contains the following license and notice below:
 

--- a/packages/studio-plugin/THIRD-PARTY-NOTICES
+++ b/packages/studio-plugin/THIRD-PARTY-NOTICES
@@ -2582,7 +2582,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - caniuse-lite@1.0.30001520
+ - caniuse-lite@1.0.30001521
 
 This package contains the following license and notice below:
 
@@ -6198,7 +6198,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The following npm packages may be included in this product:
 
- - jackspeak@2.2.3
+ - jackspeak@2.3.0
  - path-scurry@1.10.1
 
 These packages each contain the following license and notice below:

--- a/packages/studio-plugin/src/types/PagesJS.ts
+++ b/packages/studio-plugin/src/types/PagesJS.ts
@@ -11,7 +11,7 @@ export interface EntityFeature extends FeatureBase {
   entityPageSet: Record<string, never>;
 }
 
-interface StaticFeature extends FeatureBase {
+export interface StaticFeature extends FeatureBase {
   staticPage: {
     urlTemplate?: string;
     htmlTemplate?: string;

--- a/packages/studio/THIRD-PARTY-NOTICES
+++ b/packages/studio/THIRD-PARTY-NOTICES
@@ -5869,7 +5869,7 @@ THE SOFTWARE.
 
 The following npm package may be included in this product:
 
- - electron-to-chromium@1.4.491
+ - electron-to-chromium@1.4.492
 
 This package contains the following license and notice below:
 
@@ -10128,7 +10128,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 The following npm package may be included in this product:
 
- - postcss@8.4.27
+ - postcss@8.4.28
 
 This package contains the following license and notice below:
 

--- a/packages/studio/THIRD-PARTY-NOTICES
+++ b/packages/studio/THIRD-PARTY-NOTICES
@@ -3966,7 +3966,7 @@ THE SOFTWARE.
 
 The following npm package may be included in this product:
 
- - caniuse-lite@1.0.30001520
+ - caniuse-lite@1.0.30001521
 
 This package contains the following license and notice below:
 
@@ -8327,7 +8327,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 The following npm packages may be included in this product:
 
- - jackspeak@2.2.3
+ - jackspeak@2.3.0
  - path-scurry@1.10.1
 
 These packages each contain the following license and notice below:
@@ -16601,7 +16601,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - react-tooltip@5.20.0
+ - react-tooltip@5.21.1
 
 This package contains the following license and notice below:
 

--- a/packages/studio/src/store/StudioActions/CreatePageAction.ts
+++ b/packages/studio/src/store/StudioActions/CreatePageAction.ts
@@ -35,13 +35,11 @@ export default class CreatePageAction {
     );
     this.getPageSlice().addPage(pageName, pageState);
 
-    if (streamScope) {
-      const response = await this.studioActions.generateTestData();
-      if (response.type === ResponseType.Error) {
-        toast.error(
-          "Could not generate test data, but page was still created."
-        );
-      }
+    const response = await this.studioActions.generateTestData();
+    if (response.type === ResponseType.Error) {
+      toast.error(
+        "Could not generate test data, but page was still created."
+      );
     }
 
     await this.studioActions.updateActivePage(pageName);

--- a/packages/studio/src/store/StudioActions/CreatePageAction.ts
+++ b/packages/studio/src/store/StudioActions/CreatePageAction.ts
@@ -35,11 +35,13 @@ export default class CreatePageAction {
     );
     this.getPageSlice().addPage(pageName, pageState);
 
-    const response = await this.studioActions.generateTestData();
-    if (response.type === ResponseType.Error) {
-      toast.error(
-        "Could not generate test data, but page was still created."
-      );
+    if (isPagesJSRepo) {
+      const response = await this.studioActions.generateTestData();
+      if (response.type === ResponseType.Error) {
+        toast.error(
+          "Could not generate test data, but page was still created."
+        );
+      }
     }
 
     await this.studioActions.updateActivePage(pageName);

--- a/packages/studio/src/store/StudioActions/GenerateTestDataAction.ts
+++ b/packages/studio/src/store/StudioActions/GenerateTestDataAction.ts
@@ -2,6 +2,7 @@ import {
   STREAM_LOCALIZATION,
   StreamScope,
   EntityFeature,
+  StaticFeature, 
   FeaturesJson,
   MessageID,
   ResponseEventMap,
@@ -27,16 +28,18 @@ export default class GenerateTestDataAction {
       (json, pageEntry) => {
         const [pageName, pageState] = pageEntry;
         const scope = pageState.pagesJS?.streamScope;
-        if (!scope) {
-          return json;
+        if (scope) {
+          const entityFeature = GenerateTestDataAction.getEntityFeature(pageName);
+          const stream = GenerateTestDataAction.getStreamFromStreamScope(
+            scope,
+            pageName
+          );
+          json.features.push(entityFeature);
+          json.streams.push(stream);
+        } else {
+          const staticFeature = GenerateTestDataAction.getStaticFeature(pageName)
+          json.features.push(staticFeature)
         }
-        const entityFeature = GenerateTestDataAction.getEntityFeature(pageName);
-        const stream = GenerateTestDataAction.getStreamFromStreamScope(
-          scope,
-          pageName
-        );
-        json.features.push(entityFeature);
-        json.streams.push(stream);
         return json;
       },
       {
@@ -93,6 +96,14 @@ export default class GenerateTestDataAction {
       streamId: this.getStreamId(pageName),
       templateType: "JS",
       entityPageSet: {},
+    };
+  }
+
+  private static getStaticFeature(pageName: string): StaticFeature {
+    return {
+      name: pageName,
+      templateType: "JS",
+      staticPage: {}
     };
   }
 }

--- a/packages/studio/src/store/StudioActions/GenerateTestDataAction.ts
+++ b/packages/studio/src/store/StudioActions/GenerateTestDataAction.ts
@@ -2,7 +2,7 @@ import {
   STREAM_LOCALIZATION,
   StreamScope,
   EntityFeature,
-  StaticFeature, 
+  StaticFeature,
   FeaturesJson,
   MessageID,
   ResponseEventMap,
@@ -29,7 +29,8 @@ export default class GenerateTestDataAction {
         const [pageName, pageState] = pageEntry;
         const scope = pageState.pagesJS?.streamScope;
         if (scope) {
-          const entityFeature = GenerateTestDataAction.getEntityFeature(pageName);
+          const entityFeature =
+            GenerateTestDataAction.getEntityFeature(pageName);
           const stream = GenerateTestDataAction.getStreamFromStreamScope(
             scope,
             pageName
@@ -37,8 +38,9 @@ export default class GenerateTestDataAction {
           json.features.push(entityFeature);
           json.streams.push(stream);
         } else {
-          const staticFeature = GenerateTestDataAction.getStaticFeature(pageName)
-          json.features.push(staticFeature)
+          const staticFeature =
+            GenerateTestDataAction.getStaticFeature(pageName);
+          json.features.push(staticFeature);
         }
         return json;
       },
@@ -103,7 +105,7 @@ export default class GenerateTestDataAction {
     return {
       name: pageName,
       templateType: "JS",
-      staticPage: {}
+      staticPage: {},
     };
   }
 }

--- a/packages/studio/tests/store/StudioActions/GenerateTestDataAction.test.ts
+++ b/packages/studio/tests/store/StudioActions/GenerateTestDataAction.test.ts
@@ -21,6 +21,23 @@ describe("updateEntityFiles", () => {
     });
   });
 
+  it("generates entityFiles for static pages", async () => {
+    mockPageSliceStates({
+      pages: getStaticPagesRecord(),
+      activePageName: "test",
+    });
+    mockMessage({ test: ["mockLocalData.json"] });
+    await useStudioStore.getState().actions.generateTestData();
+    const pageSlice = useStudioStore.getState().pages;
+    expect(pageSlice.pages["test"].pagesJS?.entityFiles).toEqual([
+      "mockLocalData.json",
+    ]);
+    expect(pageSlice.activeEntityFile).toEqual("mockLocalData.json");
+    expect(pageSlice.activePageEntities).toEqual({
+      "mockLocalData.json": expect.anything(),
+    });
+  });
+
   it("updates entityFiles to undefined when no test data is generated", async () => {
     mockPageSliceStates({
       pages: getPagesRecord(["mockLocalData.json"]),
@@ -114,6 +131,20 @@ function getPagesRecord(entityFiles?: string[]) {
         getPathValue: undefined,
         streamScope: {},
         entityFiles,
+      },
+    },
+  };
+}
+
+function getStaticPagesRecord() {
+  return {
+    test: {
+      componentTree: [],
+      cssImports: [],
+      filepath: "mock-filepath",
+      pagesJS: {
+        getPathValue: undefined,
+        streamScope: undefined,
       },
     },
   };

--- a/packages/studio/tests/store/StudioActions/GenerateTestDataAction.test.ts
+++ b/packages/studio/tests/store/StudioActions/GenerateTestDataAction.test.ts
@@ -21,23 +21,6 @@ describe("updateEntityFiles", () => {
     });
   });
 
-  it("generates entityFiles for static pages", async () => {
-    mockPageSliceStates({
-      pages: getStaticPagesRecord(),
-      activePageName: "test",
-    });
-    mockMessage({ test: ["mockLocalData.json"] });
-    await useStudioStore.getState().actions.generateTestData();
-    const pageSlice = useStudioStore.getState().pages;
-    expect(pageSlice.pages["test"].pagesJS?.entityFiles).toEqual([
-      "mockLocalData.json",
-    ]);
-    expect(pageSlice.activeEntityFile).toEqual("mockLocalData.json");
-    expect(pageSlice.activePageEntities).toEqual({
-      "mockLocalData.json": expect.anything(),
-    });
-  });
-
   it("updates entityFiles to undefined when no test data is generated", async () => {
     mockPageSliceStates({
       pages: getPagesRecord(["mockLocalData.json"]),
@@ -131,20 +114,6 @@ function getPagesRecord(entityFiles?: string[]) {
         getPathValue: undefined,
         streamScope: {},
         entityFiles,
-      },
-    },
-  };
-}
-
-function getStaticPagesRecord() {
-  return {
-    test: {
-      componentTree: [],
-      cssImports: [],
-      filepath: "mock-filepath",
-      pagesJS: {
-        getPathValue: undefined,
-        streamScope: undefined,
       },
     },
   };

--- a/packages/studio/tests/store/StudioActions/createPage.test.ts
+++ b/packages/studio/tests/store/StudioActions/createPage.test.ts
@@ -1,6 +1,7 @@
-import { PropValueKind } from "@yext/studio-plugin";
+import { PropValueKind, ResponseType } from "@yext/studio-plugin";
 import useStudioStore from "../../../src/store/useStudioStore";
 import mockStore from "../../__utils__/mockStore";
+import * as sendMessageModule from "../../../src/messaging/sendMessage";
 
 describe("non-PagesJS repo", () => {
   it("gives an error for a relative filepath", async () => {
@@ -103,6 +104,17 @@ describe("PagesJS repo", () => {
   });
 
   it("adds a page with getPathValue to pages record", async () => {
+    jest.spyOn(sendMessageModule, "default").mockImplementation(() => {
+      return new Promise((resolve) =>
+        resolve({
+          msg: "msg",
+          type: ResponseType.Success,
+          mappingJson: {
+            testing: ["mockLocalData.json"],
+          },
+        })
+      );
+    });
     await useStudioStore.getState().actions.createPage("test", {
       kind: PropValueKind.Literal,
       value: "testing",


### PR DESCRIPTION
In https://github.com/yext/studio/pull/304, we generate test data for new entity pages when `GenerateTestData` is called.  This PR changes this to include new static pages as well. 

J=SLAP-2866
TEST=auto, manual

It was checked that when a new static page is created, it is also added in the `mapping.json` file generated by `GenerateTestData`.  Tests were modified to account for the new change that creation of static pages also call `GenerateTestData`.