### PR TITLE
Use package-lock in third party notices generation

### DIFF
--- a/.github/workflows/update-third-party-notices.yml
+++ b/.github/workflows/update-third-party-notices.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.BOT_REPO_SCOPED_TOKEN }}
 
-      # this is done since studio is a monorepo. A fresh reinstall without workspaces allows all
+      # this is done since studio is a monorepo. a fresh reinstall without workspaces allows all
       # node_modules to be installed within the current dir (instead of some at the root, with workspaces)
       # NOTE: since only changes to THIRD-PARTY-NOTICES files are added, this change will not be pushed
       - name: Clear workspace from package.json

--- a/.github/workflows/update-third-party-notices.yml
+++ b/.github/workflows/update-third-party-notices.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.BOT_REPO_SCOPED_TOKEN }}
 
-      # this is done since studio is a monorepo.  a fresh reinstall without workspaces allows all
+      # this is done since studio is a monorepo. A fresh reinstall without workspaces allows all
       # node_modules to be installed within the current dir (instead of some at the root, with workspaces)
       # NOTE: since only changes to THIRD-PARTY-NOTICES files are added, this change will not be pushed
       - name: Clear workspace from package.json
@@ -27,9 +27,15 @@ jobs:
 
       # npm install to generate node_modules which are required for generate-license-file to work
       - working-directory: packages/studio
-        run: npm install; generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite
+        run: |
+          cp ../../package-lock.json package-lock.json
+          npm install
+          generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite
       - working-directory: packages/studio-plugin
-        run: npm install; generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite
+        run: |
+          cp ../../package-lock.json package-lock.json
+          npm install
+          generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite
 
       - name: Update THIRD-PARTY-NOTICES
         id: update-notices


### PR DESCRIPTION
Before, this was not using the package-lock, resulting in the file changing essentially anytime any transitive dependency had a new non breaking release (even if we weren't using that new release yet).

J=None
TEST=manual

tested locally that I can generate third party notices, and it will include transitive dependencies