### PR TITLE
Remove Workflow call for Generating Third Party Notices

### DIFF
--- a/.github/workflows/main-workflow.yml
+++ b/.github/workflows/main-workflow.yml
@@ -14,10 +14,6 @@ jobs:
     uses: ./.github/workflows/update-tailwind-bundle.yml
     secrets: inherit
 
-  update-third-party-notices:
-    uses: ./.github/workflows/update-third-party-notices.yml
-    secrets: inherit
-
   run-tests:
     needs: automated-linting
     uses: ./.github/workflows/run-tests.yml

--- a/.github/workflows/update-third-party-notices.yml
+++ b/.github/workflows/update-third-party-notices.yml
@@ -1,4 +1,4 @@
-name: Automated Linting
+name: Generate Third Party Notices
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/update-third-party-notices.yml
+++ b/.github/workflows/update-third-party-notices.yml
@@ -1,4 +1,4 @@
-name: Generate Third Party Notices
+name: Update Third Party Notices
 on:
   workflow_call:
     secrets:


### PR DESCRIPTION
Current Third Party Notice workflow is regenerating new third party notices excessively and on very minor version changes.  We will temporarily remove this workflow until it is fixed in SLAP-2890.  I removed the workflow call, but left the workflow.

J=SLAP-2893