### PR TITLE
Create v0.19.0 of Studio and Studio-Plugin.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22768,7 +22768,7 @@
     },
     "packages/studio": {
       "name": "@yext/studio",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "dependencies": {
         "@dhmk/zustand-lens": "^2.0.5",
         "@minoru/react-dnd-treeview": "^3.4.1",
@@ -22820,7 +22820,7 @@
     },
     "packages/studio-plugin": {
       "name": "@yext/studio-plugin",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "dependencies": {
         "@babel/parser": "^7.21.8",
         "@babel/preset-env": "^7.22.4",

--- a/packages/studio-plugin/package.json
+++ b/packages/studio-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/studio-plugin",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "types": "./lib/index.d.ts",
   "main": "./lib/index.js",
   "type": "module",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/studio",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "types": "./lib/types.d.ts",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Features
- An Info button was added next to the Live Preview button. When clicked, this displays the version number of Studio. (#346)
- Number-type Props now have a Field Picker. (#344)

## Changes
- The Live Preview button is now hidden when Studio is run in Storm. The PagesJS Dev Server is also not started. (#348)
- Studio now supports PagesJS `^1.0.0-rc.1`. (#341)

## Bug Fixes
- Immer is now correctly installed as a direct dependency of Studio. (#349)