### PR TITLE
Use studio-plugin version in package.json instead of wildcard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22774,7 +22774,7 @@
         "@minoru/react-dnd-treeview": "^3.4.1",
         "@restart/ui": "^1.5.2",
         "@vitejs/plugin-react": "^4.0.4",
-        "@yext/studio-plugin": "0.19.0",
+        "@yext/studio-plugin": "0.20.0",
         "autoprefixer": "^10.4.14",
         "cac": "^6.7.14",
         "classnames": "^2.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22774,7 +22774,7 @@
         "@minoru/react-dnd-treeview": "^3.4.1",
         "@restart/ui": "^1.5.2",
         "@vitejs/plugin-react": "^4.0.4",
-        "@yext/studio-plugin": "*",
+        "@yext/studio-plugin": "0.19.0",
         "autoprefixer": "^10.4.14",
         "cac": "^6.7.14",
         "classnames": "^2.3.2",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -20,7 +20,7 @@
     "@minoru/react-dnd-treeview": "^3.4.1",
     "@restart/ui": "^1.5.2",
     "@vitejs/plugin-react": "^4.0.4",
-    "@yext/studio-plugin": "0.19.0",
+    "@yext/studio-plugin": "0.20.0",
     "autoprefixer": "^10.4.14",
     "cac": "^6.7.14",
     "classnames": "^2.3.2",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -20,7 +20,7 @@
     "@minoru/react-dnd-treeview": "^3.4.1",
     "@restart/ui": "^1.5.2",
     "@vitejs/plugin-react": "^4.0.4",
-    "@yext/studio-plugin": "*",
+    "@yext/studio-plugin": "0.19.0",
     "autoprefixer": "^10.4.14",
     "cac": "^6.7.14",
     "classnames": "^2.3.2",


### PR DESCRIPTION
In npm workspaces, you can use `*` to point to a local dependency (i.e. another package), which is how we add `studio-plugin` as a dependency of `studio`.  This dependency is preserved as a symlink in the root `package-lock.json`.  Since the dependency version of `studio-plugin` in the `studio` `package.json` was `*`, there was not a concrete version of `studio-plugin` specified, so users had to explicitly install `studio` and `studio-plugin`.  This PR finds that we can still specify a version of `studio-plugin` in the `studio` `package.json` and still preserve the symlink for local development.

J-SLAP-2895
TEST=manual