### PR TITLE
Update Studio and Studio Plugin to v0.21.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22768,13 +22768,13 @@
     },
     "packages/studio": {
       "name": "@yext/studio",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "@dhmk/zustand-lens": "^2.0.5",
         "@minoru/react-dnd-treeview": "^3.4.1",
         "@restart/ui": "^1.5.2",
         "@vitejs/plugin-react": "^4.0.4",
-        "@yext/studio-plugin": "0.20.0",
+        "@yext/studio-plugin": "0.21.0",
         "autoprefixer": "^10.4.14",
         "cac": "^6.7.14",
         "classnames": "^2.3.2",
@@ -22820,7 +22820,7 @@
     },
     "packages/studio-plugin": {
       "name": "@yext/studio-plugin",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "@babel/parser": "^7.21.8",
         "@babel/preset-env": "^7.22.4",

--- a/packages/studio-plugin/package.json
+++ b/packages/studio-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/studio-plugin",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "types": "./lib/index.d.ts",
   "main": "./lib/index.js",
   "type": "module",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/studio",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "types": "./lib/types.d.ts",
   "type": "module",
   "bin": {
@@ -20,7 +20,7 @@
     "@minoru/react-dnd-treeview": "^3.4.1",
     "@restart/ui": "^1.5.2",
     "@vitejs/plugin-react": "^4.0.4",
-    "@yext/studio-plugin": "0.20.0",
+    "@yext/studio-plugin": "0.21.0",
     "autoprefixer": "^10.4.14",
     "cac": "^6.7.14",
     "classnames": "^2.3.2",


### PR DESCRIPTION
## Changes
- Studio's startup time is now considerably faster. This is due to an improvement in the logic for parsing Component and Template files. (#357)
- The Studio Plugin is now a direct, explicit dependency of Studio. That means users only have to install `@yext/studio`. They don't need to worry about manually installing `@yext/studio-plugin` as well. (#355)