### PR TITLE
Pass the injected `YEXT_STUDIO_API_KEY` to the `ManagementApiService`.

### DIFF
--- a/packages/studio-plugin/src/createStudioPlugin.ts
+++ b/packages/studio-plugin/src/createStudioPlugin.ts
@@ -16,6 +16,7 @@ import { STUDIO_PROCESS_ARGS_OBJ } from "./constants";
 import LocalDataMappingManager from "./LocalDataMappingManager";
 import getStudioViteOptions from "./viteconfig/getStudioViteOptions";
 import { createDevServer } from "@yext/pages";
+import ManagementApiService from "./http/ManagementApiService";
 
 /**
  * Handles server-client communication.
@@ -65,6 +66,12 @@ export default async function createStudioPlugin(
   );
 
   await pagesDevPortPromise;
+
+  const managementAPIService =
+    studioConfig.isPagesJSRepo && process.env.YEXT_STUDIO_API_KEY
+      ? new ManagementApiService(process.env.YEXT_STUDIO_API_KEY)
+      : undefined;
+
   return {
     name: "yext-studio-vite-plugin",
     config(config) {
@@ -94,7 +101,8 @@ export default async function createStudioPlugin(
       orchestrator,
       localDataMappingManager,
       pathToUserProjectRoot,
-      studioConfig.paths
+      studioConfig.paths,
+      managementAPIService
     ),
   };
 }


### PR DESCRIPTION
This PR adds logic to the creation of the Studio Vite Plugin. If there is an env var called `YEXT_STUDIO_API_KEY`, we use that to create an instance of the `ManagementApiService`. This environment variable should be available in all Studio CBD containers. The value of the variable is an API Key that will give the Studio instance access to the Management API. This is the API that powers Stream Scope Selection.

TEST=manual

Tested locally. I did not have the env var set and saw that Stream Scope Selection was disabled. Then I set the env var and saw that the Scope Selection dropdowns were populated correctly.