### PR TITLE
Add HMR for layouts and remove top-level fragments

### DIFF
--- a/packages/studio/src/store/hotReloadStore.ts
+++ b/packages/studio/src/store/hotReloadStore.ts
@@ -16,7 +16,7 @@ export default async function hotReloadStore(payload: StudioHMRPayload) {
       await syncFileMetadata(studioData, payload.file);
       break;
     case "layouts":
-      // TODO SLAP-2930
+      syncLayouts(studioData);
       break;
     case "pages":
       syncPages(studioData);
@@ -32,6 +32,7 @@ export default async function hotReloadStore(payload: StudioHMRPayload) {
 
 async function fullSync(studioData: StudioData, file: string) {
   syncPages(studioData);
+  syncLayouts(studioData);
   await syncFileMetadata(studioData, file);
   syncSiteSettings(studioData);
   useStudioStore.setState((store) => {
@@ -78,6 +79,15 @@ function syncPages(studioData: StudioData) {
     store.pages.pendingChanges.pagesToRemove = new Set();
     store.pages.pendingChanges.pagesToUpdate = new Set();
     store.pages.activeComponentUUID = undefined;
+  });
+}
+
+function syncLayouts(studioData: StudioData) {
+  const layoutNameToLayoutState = removeTopLevelFragments(
+    studioData.layoutNameToLayoutState
+  );
+  useStudioStore.setState((store) => {
+    store.layouts.layouts = layoutNameToLayoutState;
   });
 }
 

--- a/packages/studio/src/store/slices/createLayoutSlice.ts
+++ b/packages/studio/src/store/slices/createLayoutSlice.ts
@@ -1,10 +1,10 @@
 import initialStudioData from "virtual_yext-studio";
 import { LayoutSlice } from "../models/slices/LayoutSlice";
 import { SliceCreator } from "../models/utils";
+import removeTopLevelFragments from "../../utils/removeTopLevelFragments";
 
 const createLayoutSlice: SliceCreator<LayoutSlice> = () => ({
-  // TODO (SLAP-2930): Remove top-level fragments from layouts
-  layouts: initialStudioData.layoutNameToLayoutState,
+  layouts: removeTopLevelFragments(initialStudioData.layoutNameToLayoutState),
 });
 
 export default createLayoutSlice;

--- a/packages/studio/src/store/slices/createPageSlice.ts
+++ b/packages/studio/src/store/slices/createPageSlice.ts
@@ -6,11 +6,11 @@ import {
 } from "@yext/studio-plugin";
 import { isEqual } from "lodash";
 import initialStudioData from "virtual_yext-studio";
-import DOMRectProperties from "../../models/DOMRectProperties";
-import PageSlice, { PageSliceStates } from "../../models/slices/PageSlice";
-import { SliceCreator } from "../../models/utils";
-import removeTopLevelFragments from "../../../utils/removeTopLevelFragments";
-import PropValueHelpers from "../../../utils/PropValueHelpers";
+import DOMRectProperties from "../models/DOMRectProperties";
+import PageSlice, { PageSliceStates } from "../models/slices/PageSlice";
+import { SliceCreator } from "../models/utils";
+import removeTopLevelFragments from "../../utils/removeTopLevelFragments";
+import PropValueHelpers from "../../utils/PropValueHelpers";
 
 const firstPageEntry = Object.entries(
   initialStudioData.pageNameToPageState

--- a/packages/studio/src/store/useStudioStore.ts
+++ b/packages/studio/src/store/useStudioStore.ts
@@ -5,7 +5,7 @@ import { enableMapSet } from "immer";
 
 import { StudioStore } from "./models/StudioStore";
 import createFileMetadataSlice from "./slices/createFileMetadataSlice";
-import createPageSlice from "./slices/pages/createPageSlice";
+import createPageSlice from "./slices/createPageSlice";
 import createSiteSettingSlice from "./slices/createSiteSettingsSlice";
 import createPagePreviewSlice from "./slices/createPagePreviewSlice";
 import StudioActions from "./StudioActions";

--- a/packages/studio/src/utils/removeTopLevelFragments.ts
+++ b/packages/studio/src/utils/removeTopLevelFragments.ts
@@ -2,15 +2,16 @@ import {
   ComponentStateKind,
   ComponentState,
   PageState,
+  LayoutState,
 } from "@yext/studio-plugin";
 
 /**
  * Iterates through a record of objects that contain a componentTree,
  * and removes all top level fragments.
  */
-export default function removeTopLevelFragments<T extends PageState>(
-  record: Record<string, T>
-): Record<string, T> {
+export default function removeTopLevelFragments<
+  T extends PageState | LayoutState
+>(record: Record<string, T>): Record<string, T> {
   const entries = Object.entries(record).map(
     ([key, componentTreeContainer]) => {
       const updatedContainer = {


### PR DESCRIPTION
This PR removes top-level fragments from the component tree of each layout in the layout slice so they won't be displayed in the UI when adding a layout to a new page. HMR is also updated to re-sync layouts in the store when a layout file is changed or a full sync is performed.

J=SLAP-2937
TEST=manual

In the test-site, saw that if `LocationLayout` had a top-level fragment, it was not present in the component tree in the `layouts` record. Also, checked that updating `LocationLayout` while running the test-site would correctly update it's component tree in the store.