### PR TITLE
Fix imports for commonly-named components

### DIFF
--- a/packages/studio-plugin/src/sourcefiles/PageFile.ts
+++ b/packages/studio-plugin/src/sourcefiles/PageFile.ts
@@ -1,6 +1,6 @@
 import { ArrowFunction, FunctionDeclaration, Project } from "ts-morph";
 import { Result } from "true-myth";
-import { PageState } from "../types";
+import { FileMetadata, PageState } from "../types";
 import TemplateConfigWriter from "../writers/TemplateConfigWriter";
 import ReactComponentFileWriter from "../writers/ReactComponentFileWriter";
 import upath from "upath";
@@ -110,8 +110,12 @@ export default class PageFile {
    * source file will be mutated to update the template configuration.
    *
    * @param updatedPageState - the updated state for the page file
+   * @param UUIDToFileMetadata - mapping of metadataUUID to FileMetadata
    */
-  updatePageFile(updatedPageState: PageState): void {
+  updatePageFile(
+    updatedPageState: PageState,
+    UUIDToFileMetadata: Record<string, FileMetadata>
+  ): void {
     const onFileUpdate = (
       pageComponent: FunctionDeclaration | ArrowFunction
     ) => {
@@ -134,6 +138,7 @@ export default class PageFile {
       componentTree: updatedPageState.componentTree,
       cssImports: updatedPageState.cssImports,
       onFileUpdate,
+      UUIDToFileMetadata,
     });
   }
 }

--- a/packages/studio-plugin/src/writers/FileSystemWriter.ts
+++ b/packages/studio-plugin/src/writers/FileSystemWriter.ts
@@ -22,7 +22,8 @@ export class FileSystemWriter {
    */
   writeToPageFile(pageName: string, pageState: PageState): void {
     const pageFile = this.orchestrator.getOrCreatePageFile(pageName);
-    pageFile.updatePageFile(pageState);
+    const UUIDToFileMetadata = this.orchestrator.getUUIDToFileMetadata();
+    pageFile.updatePageFile(pageState, UUIDToFileMetadata);
   }
 
   writeToSiteSettings(siteSettingsValues: SiteSettingsValues): void {

--- a/packages/studio-plugin/tests/FileSystemManager.test.ts
+++ b/packages/studio-plugin/tests/FileSystemManager.test.ts
@@ -12,6 +12,10 @@ import {
   PageState,
 } from "../src/types";
 import { createTestProject } from "./__utils__/createTestSourceFile";
+import * as uuidUtils from "uuid";
+
+jest.mock("uuid");
+jest.spyOn(uuidUtils, "v4").mockReturnValue("mock-metadata-uuid");
 
 const bannerComponentState: ComponentState = {
   kind: ComponentStateKind.Standard,
@@ -34,6 +38,7 @@ const projectRoot = upath.resolve(
 const tsMorphProject: Project = createTestProject();
 const paths = getUserPaths(projectRoot);
 paths.pages = upath.join(projectRoot, "pages");
+paths.components = upath.join(projectRoot, "components");
 
 const orchestrator = new ParsingOrchestrator(tsMorphProject, {
   paths,

--- a/packages/studio-plugin/tests/__fixtures__/FileSystemManager/components/Banner.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/FileSystemManager/components/Banner.tsx
@@ -1,0 +1,3 @@
+export default function Banner() {
+  return <></>;
+}

--- a/packages/studio-plugin/tests/__fixtures__/FileSystemManager/pages/UpdatedPage.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/FileSystemManager/pages/UpdatedPage.tsx
@@ -1,3 +1,5 @@
+import Banner from "../components/Banner";
+
 export default function NewPage() {
   return <Banner />;
 }

--- a/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithContainerAndText.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/PageFile/updatePageFile/PageWithContainerAndText.tsx
@@ -1,0 +1,11 @@
+import Container from "../../ComponentFile/Container";
+import Text from "../../ComponentFile/Text";
+
+export default function IndexPage() {
+  return (
+    <>
+      <Container />
+      <Text />
+    </>
+  );
+}

--- a/packages/studio-plugin/tests/__fixtures__/componentStates.ts
+++ b/packages/studio-plugin/tests/__fixtures__/componentStates.ts
@@ -105,7 +105,7 @@ export const streamConfigMultipleFieldsComponentTree: ComponentState[] = [
     componentName: "ComplexBanner",
     parentUUID: "mock-uuid-0",
     uuid: "mock-uuid-1",
-    metadataUUID: "banner-metadata",
+    metadataUUID: "mock-metadata-uuid",
     props: {
       title: {
         kind: PropValueKind.Expression,
@@ -151,7 +151,7 @@ export const streamConfigMultipleFieldsComponentTree: ComponentState[] = [
     componentName: "ComplexBanner",
     parentUUID: "mock-uuid-0",
     uuid: "mock-uuid-3",
-    metadataUUID: "banner-metadata",
+    metadataUUID: "mock-metadata-uuid",
     props: {
       title: {
         kind: PropValueKind.Expression,
@@ -165,7 +165,7 @@ export const streamConfigMultipleFieldsComponentTree: ComponentState[] = [
     componentName: "ComplexBanner",
     parentUUID: "mock-uuid-0",
     uuid: "mock-uuid-4",
-    metadataUUID: "banner-metadata",
+    metadataUUID: "mock-metadata-uuid",
     props: {
       title: {
         kind: PropValueKind.Literal,

--- a/packages/studio-plugin/tests/writers/FileSystemWriter.test.ts
+++ b/packages/studio-plugin/tests/writers/FileSystemWriter.test.ts
@@ -13,6 +13,10 @@ import {
   SiteSettingsValues,
 } from "../../src/types";
 import { createTestProject } from "../__utils__/createTestSourceFile";
+import * as uuidUtils from "uuid";
+
+jest.mock("uuid");
+jest.spyOn(uuidUtils, "v4").mockReturnValue("mock-metadata-uuid");
 
 jest.mock("fs", () => {
   const actualFs = jest.requireActual("fs");
@@ -27,6 +31,7 @@ const projectRoot = upath.resolve(
 );
 const paths = getUserPaths(projectRoot);
 paths.pages = upath.join(projectRoot, "pages");
+paths.components = upath.join(projectRoot, "components");
 paths.siteSettings = upath.join(projectRoot, "siteSettings.ts");
 
 const bannerComponentState: ComponentState = {


### PR DESCRIPTION
This PR fixes imports for commonly-named components like `Container` and `Text` by manually writing their imports to the file before calling `ts-morph`s `fixMissingImports` function. Previously, this function would often add an incorrect import in the case of `Container` and not add any import in the case of `Text`, which is also a built-in interface in React.

J=SLAP-2587
TEST=auto, manual

Added `postcss` to the test site and saw that without these changes, `Container` was imported from `postcss` (which also has a named export called `Container`), and that with these changes, `Container` is correctly imported from `src/components`. Also saw that the behavior for `Text` was fixed (i.e. an import was actually added for a `Text` component rather than it trying to use the React type).