### PR TITLE
Ignore Cached Dependencies when Starting Studio.

### DIFF
--- a/packages/studio/bin/studio.ts
+++ b/packages/studio/bin/studio.ts
@@ -18,7 +18,15 @@ cli
   .action((options: CliArgs) => {
     spawnSync(
       "npx",
-      ["cross-env", NODE_OPTIONS, "npx", "vite", "--force", "--config", pathToViteConfig],
+      [
+        "cross-env",
+        NODE_OPTIONS,
+        "npx",
+        "vite",
+        "--force",
+        "--config",
+        pathToViteConfig,
+      ],
       {
         stdio: ["ignore", "inherit", "inherit"],
         env: {

--- a/packages/studio/bin/studio.ts
+++ b/packages/studio/bin/studio.ts
@@ -18,7 +18,7 @@ cli
   .action((options: CliArgs) => {
     spawnSync(
       "npx",
-      ["cross-env", NODE_OPTIONS, "npx", "vite", "--config", pathToViteConfig],
+      ["cross-env", NODE_OPTIONS, "npx", "vite", "--force", "--config", pathToViteConfig],
       {
         stdio: ["ignore", "inherit", "inherit"],
         env: {

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -30,6 +30,6 @@ export default defineConfig((args: ConfigEnv): UserConfig => {
     plugins: [react(), createStudioPlugin(args), svgr() as PluginOption],
     css: {
       postcss: __dirname,
-    }
+    },
   };
 });

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -30,9 +30,6 @@ export default defineConfig((args: ConfigEnv): UserConfig => {
     plugins: [react(), createStudioPlugin(args), svgr() as PluginOption],
     css: {
       postcss: __dirname,
-    },
-    optimizeDeps: {
-      exclude: ["virtual_yext-studio", "virtual_yext-studio-git-data"],
-    },
+    }
   };
 });


### PR DESCRIPTION
In Vite, your project's dependencies are pre-bundled before the Dev server loads your site. As an optimization, Vite allows these bundled dependencies to be cached. If a dependency hasn't changed, Vite does not need to pre-bundle it again. See details here: https://vitejs.dev/guide/dep-pre-bundling.html#caching. Unfortunately, this caching behavior is causing significant problems in Storm (https://yext.slack.com/archives/C03F59PCJRK/p1696964495301699). 

In this PR, I remove the cache optimization from Studio's Vite instance. This is done by running Vite with `--force`. Although it wasn't strictly necessary, I also removed `optimizeDeps` from the Vite Config. Dependencies will always be pre-bundled whenever Studio starts up. Removing this optimization, I did not notice a big drop in performance locally. 

J=SLAP-2961
TEST=manual

I ran this new version of Studio against the Test Site. I verified none of the cached dependencies were used and that Studio started up as expected. 