### PR TITLE
v0.26.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24521,11 +24521,11 @@
     },
     "packages/studio": {
       "name": "@yext/studio",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "dependencies": {
         "@vitejs/plugin-react": "^4.0.4",
-        "@yext/studio-plugin": "0.25.0",
-        "@yext/studio-ui": "0.25.0",
+        "@yext/studio-plugin": "0.26.0",
+        "@yext/studio-ui": "0.26.0",
         "autoprefixer": "^10.4.14",
         "cac": "^6.7.14",
         "cross-env": "^7.0.3",
@@ -24545,7 +24545,7 @@
     },
     "packages/studio-plugin": {
       "name": "@yext/studio-plugin",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "dependencies": {
         "@babel/parser": "^7.21.8",
         "@babel/preset-env": "^7.22.4",
@@ -26658,7 +26658,7 @@
     },
     "packages/studio-ui": {
       "name": "@yext/studio-ui",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "dependencies": {
         "@dhmk/zustand-lens": "^2.0.5",
         "@minoru/react-dnd-treeview": "^3.4.1",

--- a/packages/studio-plugin/package.json
+++ b/packages/studio-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/studio-plugin",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "types": "./lib/index.d.ts",
   "main": "./lib/index.js",
   "type": "module",

--- a/packages/studio-ui/package.json
+++ b/packages/studio-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/studio-ui",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "types": "./lib/src/index.d.ts",
   "main": "./lib/src/index.js",
   "type": "module",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/studio",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "types": "./lib/types.d.ts",
   "type": "module",
   "bin": {
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@vitejs/plugin-react": "^4.0.4",
-    "@yext/studio-plugin": "0.25.0",
-    "@yext/studio-ui": "0.25.0",
+    "@yext/studio-plugin": "0.26.0",
+    "@yext/studio-ui": "0.26.0",
     "autoprefixer": "^10.4.14",
     "cac": "^6.7.14",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
## Features
- When specifying a Component's Prop Interface, you can now use the `extends` keyword. (#395)

## Changes
- Cached, pre-bundled dependencies are now ignored when starting Studio. Studio's Vite instance will pre-bundle all dependencies each time Studio is started. (#405)
- Props with a Tooltip now have an Info Icon (#403)

## Fixes
- Incorrect imports for commonly-named Components have been fixed. (#398)