### PR TITLE
Support the Omit utility type for a prop

### DIFF
--- a/packages/studio-plugin/src/parsers/PropShapeParser.ts
+++ b/packages/studio-plugin/src/parsers/PropShapeParser.ts
@@ -80,7 +80,7 @@ export default class PropShapeParser {
         type,
       };
     } else if (kind === ParsedTypeKind.Array) {
-      const itemType = this.getPropType(type, identifier);
+      const itemType = this.getPropType(type, identifier, onProp);
       return {
         type: PropValueType.Array,
         itemType,

--- a/packages/studio-plugin/src/parsers/PropShapeParser.ts
+++ b/packages/studio-plugin/src/parsers/PropShapeParser.ts
@@ -44,25 +44,30 @@ export default class PropShapeParser {
       .filter((propName) => !onProp || onProp(propName))
       .forEach((propName) => {
         const rawProp = rawProps[propName];
-        propShape[propName] = this.toPropMetadata(rawProp, identifier);
+        propShape[propName] = this.toPropMetadata(rawProp, identifier, onProp);
       });
     return propShape;
   }
 
   private toPropMetadata(
     rawProp: ParsedProperty,
-    identifier: string
+    identifier: string,
+    onProp?: (propName: string) => boolean
   ): PropMetadata {
     const { required, tooltip, displayName } = rawProp;
     return {
       ...(tooltip && { tooltip }),
       ...(displayName && { displayName }),
       required,
-      ...this.getPropType(rawProp, identifier),
+      ...this.getPropType(rawProp, identifier, onProp),
     };
   }
 
-  private getPropType(parsedType: ParsedType, identifier: string): PropType {
+  private getPropType(
+    parsedType: ParsedType,
+    identifier: string,
+    onProp?: (propName: string) => boolean
+  ): PropType {
     const { kind, type, unionValues } = parsedType;
 
     if (kind === ParsedTypeKind.StringLiteral) {
@@ -81,7 +86,7 @@ export default class PropShapeParser {
         itemType,
       };
     } else if (kind === ParsedTypeKind.Object) {
-      const nestedShape = this.toPropShape(type, identifier);
+      const nestedShape = this.toPropShape(type, identifier, onProp);
       return {
         type: PropValueType.Object,
         shape: nestedShape,

--- a/packages/studio-plugin/src/parsers/PropValuesParser.ts
+++ b/packages/studio-plugin/src/parsers/PropValuesParser.ts
@@ -75,11 +75,16 @@ export default class PropValuesParser {
   private parseRawVal(
     propName: string,
     rawVal: TypelessPropVal,
-    propType: PropType,
+    propType: PropType | undefined,
     propShape: PropShape
   ): PropVal {
+    if (!propType) {
+      throw new Error(
+        `Could not find prop type for ${propName} in ${propShape}`
+      );
+    }
     if (rawVal.kind === PropValueKind.Expression) {
-      throw new Error(`Expressions are not supported within object literal.`);
+      throw new Error("Expressions are not supported within object literal.");
     }
     const typeMatchErrorMessage = `Error parsing value of ${propName} in ${JSON.stringify(
       propShape,

--- a/packages/studio-plugin/src/parsers/helpers/StaticParsingHelpers.ts
+++ b/packages/studio-plugin/src/parsers/helpers/StaticParsingHelpers.ts
@@ -83,6 +83,11 @@ export default class StaticParsingHelpers {
         const propValues: PropValues = {};
         Object.entries(typelessValues).forEach(([propName, value]) => {
           const childMetadata = propType.shape[propName];
+          if (!childMetadata) {
+            throw new Error(
+              `Could not find prop metadata for prop ${propName} in ${propType.shape}.`
+            );
+          }
           propValues[propName] = this.addTypesToPropVal(value, childMetadata);
         });
         return propValues;

--- a/packages/studio-plugin/src/parsers/helpers/TypeNodeParsingHelper.ts
+++ b/packages/studio-plugin/src/parsers/helpers/TypeNodeParsingHelper.ts
@@ -15,6 +15,7 @@ import TypeGuards, { StudioPropValueType } from "../../utils/TypeGuards";
 import StringUnionParsingHelper from "./StringUnionParsingHelper";
 import { ParsedImport } from "../StudioSourceFileParser";
 import { STUDIO_PACKAGE_NAME } from "../../constants";
+import UtilityTypeParsingHelper from "./UtilityTypeParsingHelper";
 
 export type ParsedType =
   | SimpleParsedType
@@ -111,6 +112,16 @@ export default class TypeNodeParsingHelper {
     name: string,
     parseTypeReference: (identifier: string) => ParsedType | undefined
   ): ParsedType {
+    if (typeNode.isKind(SyntaxKind.TypeReference)) {
+      const parsedUtilityType = UtilityTypeParsingHelper.parseUtilityType(
+        typeNode,
+        (node: TypeNode) => this.parseTypeNode(node, name, parseTypeReference)
+      );
+      if (parsedUtilityType) {
+        return parsedUtilityType;
+      }
+    }
+
     if (typeNode.isKind(SyntaxKind.TypeLiteral)) {
       return this.handleObjectType(typeNode, parseTypeReference);
     } else if (

--- a/packages/studio-plugin/src/parsers/helpers/UtilityTypeParsingHelper.ts
+++ b/packages/studio-plugin/src/parsers/helpers/UtilityTypeParsingHelper.ts
@@ -1,0 +1,45 @@
+import { TypeNode, TypeReferenceNode } from "ts-morph";
+import { ParsedType, ParsedTypeKind } from "./TypeNodeParsingHelper";
+
+export default class UtilityTypeParsingHelper {
+  static parseUtilityType(
+    typeRefNode: TypeReferenceNode,
+    parseTypeNode: (node: TypeNode) => ParsedType
+  ): ParsedType | undefined {
+    const typeName = typeRefNode.getTypeName().getText();
+    const typeArgs = typeRefNode.getTypeArguments();
+
+    if (typeName === "Omit") {
+      return this.handleOmit(typeArgs, parseTypeNode);
+    }
+  }
+
+  private static handleOmit(
+    typeArgs: TypeNode[],
+    parseTypeNode: (node: TypeNode) => ParsedType
+  ): ParsedType {
+    if (typeArgs.length !== 2) {
+      throw new Error(
+        `Two type params expected for Omit utility type. Found ${typeArgs.length}.`
+      );
+    }
+
+    const [fullType, omitType] = typeArgs.map(parseTypeNode);
+
+    if (fullType.kind !== ParsedTypeKind.Object) {
+      return fullType;
+    }
+    if (omitType.kind === ParsedTypeKind.StringLiteral) {
+      delete fullType.type[omitType.type];
+      return fullType;
+    } else if (omitType.unionValues) {
+      omitType.unionValues.forEach((key) => delete fullType.type[key]);
+      return fullType;
+    } else {
+      throw new Error(
+        "Expected string literal or union of string literals for second type arg of Omit utility type." +
+          ` Found ${omitType}.`
+      );
+    }
+  }
+}

--- a/packages/studio-plugin/tests/__fixtures__/ComponentFile/MissingTypeInitialBanner.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/ComponentFile/MissingTypeInitialBanner.tsx
@@ -1,0 +1,7 @@
+export const initialProps = {
+  num: 1,
+};
+
+export default function MissingTypeInitialBanner() {
+  return <div></div>;
+}

--- a/packages/studio-plugin/tests/__fixtures__/ComponentFile/UtilityTypeBanner.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/ComponentFile/UtilityTypeBanner.tsx
@@ -1,0 +1,10 @@
+export interface UtilityTypeBannerProps {
+  title?: string;
+  missing: number;
+}
+
+export default function UtilityTypeBanner(
+  props: Omit<UtilityTypeBannerProps, "missing">
+) {
+  return <div>{props.title}</div>;
+}

--- a/packages/studio-plugin/tests/__fixtures__/SiteSettingsFile/missingDefaultExport.ts
+++ b/packages/studio-plugin/tests/__fixtures__/SiteSettingsFile/missingDefaultExport.ts
@@ -1,0 +1,4 @@
+export interface SiteSettings {
+  mySetting: string;
+  isDev: boolean;
+}

--- a/packages/studio-plugin/tests/parsers/StaticParsingHelpers.test.ts
+++ b/packages/studio-plugin/tests/parsers/StaticParsingHelpers.test.ts
@@ -81,7 +81,7 @@ describe("parseJsxAttributes", () => {
   };
 
   it("skips special React props", () => {
-    const sourceCode = `function Test() { return <Banner title="Name" key={1} />; }`;
+    const sourceCode = `<Banner title="Name" key={1} />`;
     const jsxAttributes = getJsxAttributesFromSource(sourceCode);
     const receivedPropValues = StaticParsingHelpers.parseJsxAttributes(
       jsxAttributes,
@@ -97,16 +97,30 @@ describe("parseJsxAttributes", () => {
     expect(receivedPropValues).toEqual(expectedPropValues);
   });
 
-  it("throws an error if a prop type isn't found", () => {
-    const sourceCode = `function Test() { return <Banner num={1} />; }`;
+  it("throws an error if a prop type isn't found for top-level prop", () => {
+    const sourceCode = `function Test() { return <Banner number={1} />; }`;
     const jsxAttributes = getJsxAttributesFromSource(sourceCode);
     expect(() =>
-      StaticParsingHelpers.parseJsxAttributes(jsxAttributes, propShape)
+      StaticParsingHelpers.parseJsxAttributes(jsxAttributes, {})
     ).toThrowError(/^Could not find prop metadata for:/);
   });
 
+  it("throws an error if a prop type isn't found for a nested prop", () => {
+    const sourceCode = `function Test(props: { obj: {} }) { return <Banner obj={{ num: 1 }} />; }`;
+    const jsxAttributes = getJsxAttributesFromSource(sourceCode);
+    expect(() =>
+      StaticParsingHelpers.parseJsxAttributes(jsxAttributes, {
+        obj: {
+          type: PropValueType.Object,
+          required: true,
+          shape: {},
+        },
+      })
+    ).toThrowError(/^Could not find prop metadata for prop/);
+  });
+
   it("throws an error if a prop value is invalid", () => {
-    const sourceCode = `function Test() { return <Banner title={1} />; }`;
+    const sourceCode = `<Banner title={1} />`;
     const jsxAttributes = getJsxAttributesFromSource(sourceCode);
     expect(() =>
       StaticParsingHelpers.parseJsxAttributes(jsxAttributes, propShape)

--- a/packages/studio-plugin/tests/parsers/helpers/TypeNodeParsingHelper.test.ts
+++ b/packages/studio-plugin/tests/parsers/helpers/TypeNodeParsingHelper.test.ts
@@ -184,6 +184,34 @@ it("throws an error if Array TypeReference is missing a type param", () => {
   ).toThrowError("One type param expected for Array type. Found 0.");
 });
 
+it("can parse a prop with an Omit utility type", () => {
+  const { sourceFile } = createTestSourceFile(
+    `export type MyProps = {
+      omit: Omit<{ name?: string, nope: number }, "nope">;
+    }`
+  );
+  const typeAlias = sourceFile.getFirstDescendantByKindOrThrow(
+    SyntaxKind.TypeAliasDeclaration
+  );
+  const parsedShape = TypeNodeParsingHelper.parseShape(
+    typeAlias,
+    externalShapeParser
+  );
+  expect(parsedShape.type).toEqual({
+    omit: {
+      kind: ParsedTypeKind.Object,
+      required: true,
+      type: {
+        name: {
+          kind: ParsedTypeKind.Simple,
+          required: false,
+          type: "string",
+        },
+      },
+    },
+  });
+});
+
 it("can parse the @displayName and @tooltip tag", () => {
   const { sourceFile } = createTestSourceFile(
     `export type MyProps = {

--- a/packages/studio-plugin/tests/parsers/helpers/UtilityTypeParsingHelper.test.ts
+++ b/packages/studio-plugin/tests/parsers/helpers/UtilityTypeParsingHelper.test.ts
@@ -159,13 +159,10 @@ describe("omit", () => {
     );
 
     const omitType: ParsedType = {
-      kind: ParsedTypeKind.Object,
+      kind: ParsedTypeKind.Array,
       type: {
-        num: {
-          kind: ParsedTypeKind.Simple,
-          required: true,
-          type: "number",
-        },
+        kind: ParsedTypeKind.Simple,
+        type: "string",
       },
     };
 

--- a/packages/studio-plugin/tests/parsers/helpers/UtilityTypeParsingHelper.test.ts
+++ b/packages/studio-plugin/tests/parsers/helpers/UtilityTypeParsingHelper.test.ts
@@ -1,0 +1,181 @@
+import { SyntaxKind, TypeNode } from "ts-morph";
+import createTestSourceFile from "../../__utils__/createTestSourceFile";
+import UtilityTypeParsingHelper from "../../../src/parsers/helpers/UtilityTypeParsingHelper";
+import {
+  ParsedProperty,
+  ParsedType,
+  ParsedTypeKind,
+} from "../../../src/parsers/helpers/TypeNodeParsingHelper";
+import cloneDeep from "lodash/cloneDeep";
+
+const nameProp: ParsedProperty = {
+  kind: ParsedTypeKind.Simple,
+  required: false,
+  type: "string",
+};
+
+const numProp: ParsedProperty = {
+  kind: ParsedTypeKind.Simple,
+  required: true,
+  type: "number",
+};
+
+const arrProp: ParsedProperty = {
+  kind: ParsedTypeKind.Array,
+  required: true,
+  type: {
+    kind: ParsedTypeKind.Simple,
+    type: "boolean",
+  },
+};
+
+const fullObjectType: ParsedType = {
+  kind: ParsedTypeKind.Object,
+  type: {
+    name: nameProp,
+    num: numProp,
+    arr: arrProp,
+  },
+};
+
+function mockedParseTypeNodeCreator(
+  omitType: ParsedType,
+  fullType = cloneDeep(fullObjectType)
+): (node: TypeNode) => ParsedType {
+  return (node: TypeNode) =>
+    node.isKind(SyntaxKind.TypeLiteral) ? fullType : omitType;
+}
+
+describe("omit", () => {
+  it("can handle a single omitted type", () => {
+    const { sourceFile } = createTestSourceFile(
+      `type MyOmit = Omit<{ name?: string, num: number, arr: boolean[] }, "num">;
+      }`
+    );
+    const typeRef = sourceFile.getFirstDescendantByKindOrThrow(
+      SyntaxKind.TypeReference
+    );
+    const parsedType = UtilityTypeParsingHelper.parseUtilityType(
+      typeRef,
+      mockedParseTypeNodeCreator({
+        kind: ParsedTypeKind.StringLiteral,
+        type: "num",
+      })
+    );
+    expect(parsedType?.type).toEqual({
+      name: nameProp,
+      arr: arrProp,
+    });
+  });
+
+  it("can handle multiple omitted types", () => {
+    const { sourceFile } = createTestSourceFile(
+      `type MyOmit = Omit<{ name?: string, num: number, arr: boolean[] }, "name" | "num">;
+      }`
+    );
+    const typeRef = sourceFile.getFirstDescendantByKindOrThrow(
+      SyntaxKind.TypeReference
+    );
+    const parsedType = UtilityTypeParsingHelper.parseUtilityType(
+      typeRef,
+      mockedParseTypeNodeCreator({
+        kind: ParsedTypeKind.Simple,
+        type: "string",
+        unionValues: ["name", "num"],
+      })
+    );
+    expect(parsedType?.type).toEqual({ arr: arrProp });
+  });
+
+  it("can handle non-overlapping omitted type", () => {
+    const { sourceFile } = createTestSourceFile(
+      `type MyOmit = Omit<{ name?: string, num: number, arr: boolean[] }, "boo">;
+      }`
+    );
+    const typeRef = sourceFile.getFirstDescendantByKindOrThrow(
+      SyntaxKind.TypeReference
+    );
+    const parsedType = UtilityTypeParsingHelper.parseUtilityType(
+      typeRef,
+      mockedParseTypeNodeCreator({
+        kind: ParsedTypeKind.StringLiteral,
+        type: "boo",
+      })
+    );
+    expect(parsedType?.type).toEqual({
+      name: nameProp,
+      num: numProp,
+      arr: arrProp,
+    });
+  });
+
+  it("does not change non-object types", () => {
+    const { sourceFile } = createTestSourceFile(
+      `type MyOmit = Omit<"test", "test">;
+      }`
+    );
+    const typeRef = sourceFile.getFirstDescendantByKindOrThrow(
+      SyntaxKind.TypeReference
+    );
+    const testParsedType: ParsedType = {
+      kind: ParsedTypeKind.StringLiteral,
+      type: "test",
+    };
+
+    const parsedType = UtilityTypeParsingHelper.parseUtilityType(
+      typeRef,
+      mockedParseTypeNodeCreator(testParsedType, testParsedType)
+    );
+    expect(parsedType).toEqual(testParsedType);
+  });
+
+  it("throws an error if there an incorrect number of type arguments", () => {
+    const { sourceFile } = createTestSourceFile(
+      `type MyOmit = Omit<{ name?: string, num: number, arr: boolean[] }, "name", "num">;
+      }`
+    );
+    const typeRef = sourceFile.getFirstDescendantByKindOrThrow(
+      SyntaxKind.TypeReference
+    );
+
+    expect(() =>
+      UtilityTypeParsingHelper.parseUtilityType(
+        typeRef,
+        mockedParseTypeNodeCreator({
+          kind: ParsedTypeKind.StringLiteral,
+          type: "name",
+        })
+      )
+    ).toThrowError("Two type params expected for Omit utility type. Found 3.");
+  });
+
+  it("throws an error if the omit type is not a string literal or union of string literals", () => {
+    const { sourceFile } = createTestSourceFile(
+      `type MyOmit = Omit<{ name?: string, num: number, arr: boolean[] }, { num: number }>;
+      }`
+    );
+    const typeRef = sourceFile.getFirstDescendantByKindOrThrow(
+      SyntaxKind.TypeReference
+    );
+
+    const omitType: ParsedType = {
+      kind: ParsedTypeKind.Object,
+      type: {
+        num: {
+          kind: ParsedTypeKind.Simple,
+          required: true,
+          type: "number",
+        },
+      },
+    };
+
+    expect(() =>
+      UtilityTypeParsingHelper.parseUtilityType(
+        typeRef,
+        mockedParseTypeNodeCreator(omitType)
+      )
+    ).toThrowError(
+      `Expected string literal or union of string literals for second type arg of Omit utility type. Found ${omitType}.`
+    );
+  });
+});

--- a/packages/studio-plugin/tests/parsers/helpers/UtilityTypeParsingHelper.test.ts
+++ b/packages/studio-plugin/tests/parsers/helpers/UtilityTypeParsingHelper.test.ts
@@ -151,7 +151,7 @@ describe("omit", () => {
 
   it("throws an error if the omit type is not a string literal or union of string literals", () => {
     const { sourceFile } = createTestSourceFile(
-      `type MyOmit = Omit<{ name?: string, num: number, arr: boolean[] }, { num: number }>;
+      `type MyOmit = Omit<{ name?: string, num: number, arr: boolean[] }, Array<string>>;
       }`
     );
     const typeRef = sourceFile.getFirstDescendantByKindOrThrow(

--- a/packages/studio-plugin/tests/sourcefiles/ComponentFile.test.ts
+++ b/packages/studio-plugin/tests/sourcefiles/ComponentFile.test.ts
@@ -215,6 +215,14 @@ describe("getComponentMetadata", () => {
     );
   });
 
+  it("Throws an Error when an prop type is missing for prop within initialProps", () => {
+    const pathToComponent = getComponentPath("MissingTypeInitialBanner");
+    const componentFile = new ComponentFile(pathToComponent, project);
+    expect(componentFile.getComponentMetadata()).toHaveErrorMessage(
+      /^Could not find prop type for/
+    );
+  });
+
   it("Throws an Error when an Expression is used within initialProps", () => {
     const pathToComponent = getComponentPath("ExpressionInitialBanner");
     const componentFile = new ComponentFile(pathToComponent, project);

--- a/packages/studio-plugin/tests/sourcefiles/ComponentFile.test.ts
+++ b/packages/studio-plugin/tests/sourcefiles/ComponentFile.test.ts
@@ -183,6 +183,14 @@ describe("getComponentMetadata", () => {
     });
   });
 
+  it("Throws an Error if the prop interface is a utility type", () => {
+    const pathToComponent = getComponentPath("UtilityTypeBanner");
+    const componentFile = new ComponentFile(pathToComponent, project);
+    expect(componentFile.getComponentMetadata()).toHaveErrorMessage(
+      'Unable to resolve type Omit<UtilityTypeBannerProps, "missing">.'
+    );
+  });
+
   it("Throws an Error if HexColor is not imported from Studio", () => {
     const pathToComponent = getComponentPath("NonStudioImportBanner");
     const componentFile = new ComponentFile(pathToComponent, project);

--- a/packages/studio-plugin/tests/sourcefiles/SiteSettingsFile.test.ts
+++ b/packages/studio-plugin/tests/sourcefiles/SiteSettingsFile.test.ts
@@ -38,9 +38,19 @@ describe("getSiteSettings", () => {
     expect(siteSettingsFile.getSiteSettings()).toEqual(expectedSiteSettings);
   });
 
-  it("errors out if the default export is missing", () => {
+  it("errors out if SiteSettings interface is missing", () => {
     const siteSettingsFile = new SiteSettingsFile(
       getSiteSettingsPath("blankFile.ts"),
+      tsMorphProject
+    );
+    expect(() => siteSettingsFile.getSiteSettings()).toThrow(
+      "Unable to resolve type SiteSettings."
+    );
+  });
+
+  it("errors out if the default export is missing", () => {
+    const siteSettingsFile = new SiteSettingsFile(
+      getSiteSettingsPath("missingDefaultExport.ts"),
       tsMorphProject
     );
     expect(() => siteSettingsFile.getSiteSettings()).toThrow(


### PR DESCRIPTION
This PR adds support for the `Omit` TypeScript utility type when defining the type of a prop in a component's prop interface. For now, utility types are still not allowed when defining the overall type of the component's prop interface (i.e. `props: Omit<MyProps, "blah">`).

This PR also adds a few new errors:
- An error for when we're unable to locate/resolve a component's prop interface (for example, if they use a utility type for the overall type as mentioned above). Previously, we would silently continue and assume there were no props for the component, which could throw obscure TS errors later on when parsing.
- An error for when a value was present for a field within an object prop on an instance of a component in a PageFile, but that field wasn't defined in the prop interface of that component. This would also throw an unclear TS error previously.
- An error for when an initial prop was present for a component that wasn't defined in its prop interface. This would also throw an unclear TS error previously.

J=SLAP-2967
TEST=auto, manual

In the test site, see that using `Omit<ObjectProp, "nestedBool">` instead of `ObjectProp` for the type of `obj` in `BannerData` correctly results in the prop editor for `nestedBool` not appearing in the UI.