### PR TITLE
Support the Required utility type for a prop

### DIFF
--- a/packages/studio-plugin/src/parsers/helpers/UtilityTypeParsingHelper.ts
+++ b/packages/studio-plugin/src/parsers/helpers/UtilityTypeParsingHelper.ts
@@ -24,6 +24,8 @@ export default class UtilityTypeParsingHelper {
           return this.handleOmit;
         case "Pick":
           return this.handlePick;
+        case "Required":
+          return this.handleRequired;
       }
     })();
     return utilityTypeHandler?.(typeArgs, parseTypeNode);
@@ -97,6 +99,41 @@ export default class UtilityTypeParsingHelper {
     return {
       ...fullType,
       type: reducedShape,
+    };
+  };
+
+  private static handleRequired: UtilityTypeHandler = (
+    typeArgs,
+    parseTypeNode
+  ) => {
+    if (typeArgs.length !== 1) {
+      throw new Error(
+        `One type param expected for Required utility type. Found ${typeArgs.length}.`
+      );
+    }
+
+    const originalType = parseTypeNode(typeArgs[0]);
+
+    if (originalType.kind !== ParsedTypeKind.Object) {
+      return originalType;
+    }
+
+    const updatedShape: ParsedShape = Object.entries(originalType.type).reduce(
+      (updatedShape, [key, property]) => {
+        return {
+          ...updatedShape,
+          [key]: {
+            ...property,
+            required: true,
+          },
+        };
+      },
+      {}
+    );
+
+    return {
+      ...originalType,
+      type: updatedShape,
     };
   };
 }


### PR DESCRIPTION
This PR adds support for the `Required` TypeScript utility type when defining the type of a prop in a component's prop interface. As mentioned in the previous PR, utility types are still not allowed when defining the overall type of the component's prop interface (i.e. `props: Required<MyProps>`).

J=SLAP-2969
TEST=auto, manual

In the test site, see that using `Required<ObjectProp>` instead of `ObjectProp` for the type of `obj` in `BannerData` correctly results in the prop editors for `nestedString`, `nestedBool`, and `nestedObj` no longer displaying the undefined menu button icon in the UI, while all other prop editors were unchanged.