### PR TITLE
Ensure `_client` and `_server` Templates Don't Appear in Studio.

### DIFF
--- a/packages/studio-plugin/src/orchestrators/ParsingOrchestrator.ts
+++ b/packages/studio-plugin/src/orchestrators/ParsingOrchestrator.ts
@@ -214,7 +214,14 @@ export default class ParsingOrchestrator {
         `The pages directory does not exist, expected directory to be at "${this.paths.pages}".`
       );
     }
-    return createFilenameMapping(this.paths.pages, this.getOrCreatePageFile);
+
+    const excludeReservedPagesJSFiles = (filename: string) =>
+      !(filename.includes("_server") || filename.includes("_client"));
+    return createFilenameMapping(
+      this.paths.pages,
+      this.getOrCreatePageFile,
+      excludeReservedPagesJSFiles
+    );
   }
 
   private getSiteSettings(): SiteSettings | undefined {

--- a/packages/studio-plugin/src/orchestrators/ParsingOrchestrator.ts
+++ b/packages/studio-plugin/src/orchestrators/ParsingOrchestrator.ts
@@ -215,13 +215,18 @@ export default class ParsingOrchestrator {
       );
     }
 
-    const excludeReservedPagesJSFiles = (filename: string) =>
-      !(filename.includes("_server") || filename.includes("_client"));
-    return createFilenameMapping(
-      this.paths.pages,
-      this.getOrCreatePageFile,
-      excludeReservedPagesJSFiles
-    );
+    if (this.studioConfig.isPagesJSRepo) {
+      const excludeReservedPagesJSFiles = (filename: string) =>
+        !(filename.includes("_server") || filename.includes("_client"));
+
+      return createFilenameMapping(
+        this.paths.pages,
+        this.getOrCreatePageFile,
+        excludeReservedPagesJSFiles
+      );
+    }
+
+    return createFilenameMapping(this.paths.pages, this.getOrCreatePageFile);
   }
 
   private getSiteSettings(): SiteSettings | undefined {

--- a/packages/studio-plugin/src/orchestrators/createFilenameMapping.ts
+++ b/packages/studio-plugin/src/orchestrators/createFilenameMapping.ts
@@ -3,11 +3,14 @@ import upath from "upath";
 
 export default function createFilenameMapping<T>(
   dirPath: string,
-  getMappedValue: (name: string) => T
+  getMappedValue: (name: string) => T,
+  fileFilter?: (filename: string) => boolean
 ): Record<string, T> {
   const files = fs.readdirSync(dirPath, "utf-8").filter((filename) => {
     const absPath = upath.join(dirPath, filename);
-    return fs.lstatSync(absPath).isFile();
+
+    const isFile = fs.lstatSync(absPath).isFile();
+    return fileFilter ? isFile && fileFilter(filename) : isFile;
   });
   return files.reduce((filepathMapping, filename) => {
     const name = upath.basename(filename, ".tsx");

--- a/packages/studio-plugin/tests/__fixtures__/ParsingOrchestrator/src/pages/_client.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/ParsingOrchestrator/src/pages/_client.tsx
@@ -1,0 +1,12 @@
+import { PageContext } from "@yext/pages";
+import { hydrateRoot } from "react-dom/client";
+
+export { render };
+
+const render = async (pageContext: PageContext<any>) => {
+  const { Page, pageProps } = pageContext;
+  const rootElement = document.getElementById("reactele");
+  if (rootElement) {
+    hydrateRoot(rootElement, <Page {...pageProps} />);
+  }
+};

--- a/packages/studio-plugin/tests/__fixtures__/ParsingOrchestrator/src/pages/_server.tsx
+++ b/packages/studio-plugin/tests/__fixtures__/ParsingOrchestrator/src/pages/_server.tsx
@@ -1,0 +1,19 @@
+import * as ReactDOMServer from "react-dom/server";
+import { PageContext } from "@yext/pages";
+
+export { render };
+
+const render = async (pageContext: PageContext<any>) => {
+  const { Page, pageProps } = pageContext;
+  const viewHtml = ReactDOMServer.renderToString(<Page {...pageProps} />);
+  return `<!DOCTYPE html>
+    <html lang="<!--app-lang-->">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
+      <body>
+        <div id="reactele">${viewHtml}</div>
+      </body>
+    </html>`;
+};

--- a/packages/studio-plugin/tests/orchestrators/ParsingOrchestrator.test.ts
+++ b/packages/studio-plugin/tests/orchestrators/ParsingOrchestrator.test.ts
@@ -43,7 +43,7 @@ const basicPageState: PageState = {
 };
 
 describe("aggregates data as expected", () => {
-  const orchestrator = createParsingOrchestrator({ isPagesJS: true });
+  const orchestrator = createParsingOrchestrator();
   let studioData: StudioData;
 
   beforeAll(() => {
@@ -68,12 +68,10 @@ describe("aggregates data as expected", () => {
     );
   });
 
-  it("properly populates PageState Records, ignoring sub-directories and reserved PagesJS Files", () => {
+  it("properly populates pageNameToPageState, ignoring sub-directories", () => {
     expect(studioData.pageNameToPageState).toEqual({
       basicPage: basicPageState,
     });
-
-    expect(studioData.pageNameToErrorPageState).toEqual({});
   });
 
   it("properly populates siteSettings", () => {
@@ -113,6 +111,7 @@ describe("aggregates data as expected", () => {
         isPagesJS: true,
       });
       const studioData = orchestrator.getStudioData();
+      expect(studioData.pageNameToErrorPageState).toEqual({});
       expect(studioData.pageNameToPageState).toEqual({
         basicPage: {
           ...basicPageState,
@@ -132,7 +131,7 @@ it("throws an error when the page imports components from unexpected folders", (
     __dirname,
     "../__fixtures__/ParsingOrchestrator/src/pages"
   );
-  createParsingOrchestrator({ paths: userPaths }).getStudioData();
+  createParsingOrchestrator({ paths: userPaths, isPagesJS: true }).getStudioData();
   expect(prettyPrintError).toHaveBeenCalledTimes(1);
   expect(prettyPrintError).toHaveBeenCalledWith(
     expect.stringMatching(/^Failed to parse PageState/),

--- a/packages/studio-plugin/tests/orchestrators/ParsingOrchestrator.test.ts
+++ b/packages/studio-plugin/tests/orchestrators/ParsingOrchestrator.test.ts
@@ -68,10 +68,12 @@ describe("aggregates data as expected", () => {
     );
   });
 
-  it("properly populates pageNameToPageState, ignoring sub-directories", () => {
+  it("properly populates PageState Records, ignoring sub-directories and reserved PagesJS Files", () => {
     expect(studioData.pageNameToPageState).toEqual({
       basicPage: basicPageState,
     });
+
+    expect(studioData.pageNameToErrorPageState).toEqual({});
   });
 
   it("properly populates siteSettings", () => {

--- a/packages/studio-plugin/tests/orchestrators/ParsingOrchestrator.test.ts
+++ b/packages/studio-plugin/tests/orchestrators/ParsingOrchestrator.test.ts
@@ -43,7 +43,7 @@ const basicPageState: PageState = {
 };
 
 describe("aggregates data as expected", () => {
-  const orchestrator = createParsingOrchestrator();
+  const orchestrator = createParsingOrchestrator({ isPagesJS: true });
   let studioData: StudioData;
 
   beforeAll(() => {

--- a/packages/studio-plugin/tests/orchestrators/ParsingOrchestrator.test.ts
+++ b/packages/studio-plugin/tests/orchestrators/ParsingOrchestrator.test.ts
@@ -131,7 +131,10 @@ it("throws an error when the page imports components from unexpected folders", (
     __dirname,
     "../__fixtures__/ParsingOrchestrator/src/pages"
   );
-  createParsingOrchestrator({ paths: userPaths, isPagesJS: true }).getStudioData();
+  createParsingOrchestrator({
+    paths: userPaths,
+    isPagesJS: true,
+  }).getStudioData();
   expect(prettyPrintError).toHaveBeenCalledTimes(1);
   expect(prettyPrintError).toHaveBeenCalledWith(
     expect.stringMatching(/^Failed to parse PageState/),

--- a/packages/studio-ui/src/utils/PageDataValidator.ts
+++ b/packages/studio-ui/src/utils/PageDataValidator.ts
@@ -1,5 +1,7 @@
 import { PagesRecord } from "../store/models/slices/PageSlice";
 
+export const PAGES_JS_RESERVED_PAGE_NAMES = ["_server", "_client"];
+
 export interface ValidationResult {
   valid: boolean;
   errorMessages: string[];
@@ -75,6 +77,9 @@ export default class PageDataValidator {
     }
     if (pageName.length > 255) {
       errorMessages.push("Page name must be 255 characters or less.");
+    }
+    if (this.isPagesJSRepo && PAGES_JS_RESERVED_PAGE_NAMES.includes(pageName)) {
+      errorMessages.push(`Page name "${pageName}" is a reserved PagesJS filename.`);
     }
     if (this.pages[pageName]) {
       errorMessages.push(`Page name "${pageName}" is already used.`);

--- a/packages/studio-ui/src/utils/PageDataValidator.ts
+++ b/packages/studio-ui/src/utils/PageDataValidator.ts
@@ -79,7 +79,9 @@ export default class PageDataValidator {
       errorMessages.push("Page name must be 255 characters or less.");
     }
     if (this.isPagesJSRepo && PAGES_JS_RESERVED_PAGE_NAMES.includes(pageName)) {
-      errorMessages.push(`Page name "${pageName}" is a reserved PagesJS filename.`);
+      errorMessages.push(
+        `Page name "${pageName}" is a reserved PagesJS filename.`
+      );
     }
     if (this.pages[pageName]) {
       errorMessages.push(`Page name "${pageName}" is already used.`);

--- a/packages/studio-ui/tests/utils/PageDataValidator.test.ts
+++ b/packages/studio-ui/tests/utils/PageDataValidator.test.ts
@@ -49,7 +49,7 @@ describe("page name validation", () => {
     isEntityPage: false,
     isPagesJSRepo: true,
   });
-  
+
   function expectPageNameError(input: string, errorMessages: string[]) {
     const result: ValidationResult = validator.validate({ pageName: input });
     expect(result.valid).toBeFalsy();
@@ -81,7 +81,7 @@ describe("page name validation", () => {
     const checkReservedName = (pageName: string) => {
       const errorMessage = `Page name "${pageName}" is a reserved PagesJS filename.`;
       expectPageNameError(pageName, [errorMessage]);
-    }
+    };
 
     PAGES_JS_RESERVED_PAGE_NAMES.forEach((name) => checkReservedName(name));
   });

--- a/packages/studio-ui/tests/utils/PageDataValidator.test.ts
+++ b/packages/studio-ui/tests/utils/PageDataValidator.test.ts
@@ -1,4 +1,5 @@
 import PageDataValidator, {
+  PAGES_JS_RESERVED_PAGE_NAMES,
   ValidationResult,
 } from "../../src/utils/PageDataValidator";
 
@@ -44,11 +45,12 @@ describe("URL slug validation", () => {
 });
 
 describe("page name validation", () => {
+  const validator = new PageDataValidator({
+    isEntityPage: false,
+    isPagesJSRepo: true,
+  });
+  
   function expectPageNameError(input: string, errorMessages: string[]) {
-    const validator = new PageDataValidator({
-      isEntityPage: false,
-      isPagesJSRepo: true,
-    });
     const result: ValidationResult = validator.validate({ pageName: input });
     expect(result.valid).toBeFalsy();
     expect(result.errorMessages).toEqual(expect.arrayContaining(errorMessages));
@@ -73,5 +75,14 @@ describe("page name validation", () => {
     const longName = "a".repeat(256);
     const errorMessage = "Page name must be 255 characters or less.";
     expectPageNameError(longName, [errorMessage]);
+  });
+
+  it("gives an error when using PagesJS Reserved Filenames", () => {
+    const checkReservedName = (pageName: string) => {
+      const errorMessage = `Page name "${pageName}" is a reserved PagesJS filename.`;
+      expectPageNameError(pageName, [errorMessage]);
+    }
+
+    PAGES_JS_RESERVED_PAGE_NAMES.forEach((name) => checkReservedName(name));
   });
 });


### PR DESCRIPTION
This PR ensures Studio will not display the `_client.tsx` or `_server.tsx` Templates. These Templates are reserved files in PagesJS. They don't actually correspond to a Page, but instead dictate how SSR works. In the future, we will be able to exclude these files by supporting Globs in the Studio Config's paths. For now, Product does not have the appetite for adding Globs. 

We now prevent someone from adding a Page in Studio whose filename is `_client` or `_server` (assuming they're in PagesJS mode). 

J=SLAP-2960
TEST=auto, manual