### PR TITLE
Tooltip Wrap Text

### DIFF
--- a/packages/studio-ui/src/components/common/TooltipIcon.tsx
+++ b/packages/studio-ui/src/components/common/TooltipIcon.tsx
@@ -3,6 +3,10 @@ import { Tooltip } from "react-tooltip";
 import { v4 } from "uuid";
 import { ReactComponent as Info } from "../../icons/info.svg";
 
+const tooltipCssStyle = {
+  "maxWidth": "23.5%",
+}
+
 export interface TooltipIconProps {
   content: string;
 }
@@ -12,12 +16,15 @@ export default function TooltipIcon({ content }: TooltipIconProps) {
 
   return (
     <div>
-      <Info id={tooltipId} className="ml-3 pb-1" data-testid="prop-tooltip" />
+      <Info id={tooltipId} className="ml-1 pb-1 mr-4" data-testid="prop-tooltip" />
       <Tooltip
         className="bg-black z-20"
         anchorId={tooltipId}
         content={content}
-        place="left"
+        place="top"
+        closeOnScroll={true}
+        positionStrategy="fixed"
+        style={tooltipCssStyle}
       />
     </div>
   );


### PR DESCRIPTION
This PR allows the tooltip to wrap when the text is too long, as opposed to getting cut off by the end of the screen. I've attached some screen shots to show some of the edge cases.  This tooltip closes on scroll, and will work as expected in different scrolled positions.  Although it has "fixed" positioning, react-tooltip ensures that scroll behavior works as expected.

Short tooltips
<img width="419" alt="image" src="https://github.com/yext/studio/assets/59857107/bfcbadea-0c53-4494-8392-83afc9262b05">

Long tooltips, even with horizontal scroll
<img width="419" alt="image" src="https://github.com/yext/studio/assets/59857107/e91169fe-819f-4648-b148-8726d62ece97">

J=SLAP-2958
TEST=manual
